### PR TITLE
Fix: Resolve container migration path and import errors

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -48,6 +48,7 @@ EXPOSE 5000
 ENV DATABASE_PATH=/app/data/sheepvibes.db \
     UPDATE_INTERVAL_MINUTES=15 \
     FLASK_APP=backend.app \
+    PYTHONPATH=/app \
     FLASK_RUN_HOST=0.0.0.0
     # Note: FLASK_DEBUG should be 0 or unset for production
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -7,15 +7,16 @@ set -e
 # Note: In the container, the venv is at /opt/venv as per Containerfile
 . /opt/venv/bin/activate
 
-# Navigate to the backend directory where Flask app and migrations are
-cd /app
-
-echo "Applying database migrations..."
+# Navigate to the backend directory for migrations
+cd /app/backend
+echo "Applying database migrations from $(pwd)..."
 # Apply database migrations using python -m flask from venv
 # FLASK_APP is already set as an ENV variable in the Containerfile
 /opt/venv/bin/python -m flask db upgrade
 
-echo "Starting Flask application..."
+# Go back to the main app directory to run the application
+cd /app
+echo "Starting Flask application from $(pwd)..."
 # Execute the main container command using python -m flask from venv
 # Using exec means the Flask process replaces the shell script process
 exec /opt/venv/bin/python -m flask run


### PR DESCRIPTION
This commit addresses issues with container startup:
1.  Ensures Flask-Migrate correctly finds the 'migrations' directory.
2.  Ensures Python correctly resolves module imports for the Flask app.

Changes:
-   **Containerfile**:
    - Added `ENV PYTHONPATH=/app`. This allows Python to correctly
      locate the `backend` package when `FLASK_APP=backend.app` is used,
      irrespective of the flask command's current working directory.

-   **scripts/entrypoint.sh**:
    - The script now changes to `/app/backend` before running
      `flask db upgrade`. This ensures that Flask-Migrate can find the
      `migrations` directory (which is in `/app/backend`).
    - It then changes to `/app` before running `flask run` for executing
      the application. `FLASK_APP=backend.app` is found via `PYTHONPATH`.

This combination ensures that database migrations are applied correctly and the Flask application starts without import errors.