### PR TITLE
Fix: Explicitly specify Flask app context in entrypoint

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,14 +9,14 @@ set -e
 
 # Navigate to the backend directory for migrations
 cd /app/backend
-echo "Applying database migrations from $(pwd)..."
+echo "Applying database migrations from $(pwd) using app 'app'..."
 # Apply database migrations using python -m flask from venv
 # FLASK_APP is already set as an ENV variable in the Containerfile
-/opt/venv/bin/python -m flask db upgrade
+/opt/venv/bin/python -m flask --app app db upgrade
 
 # Go back to the main app directory to run the application
 cd /app
-echo "Starting Flask application from $(pwd)..."
+echo "Starting Flask application from $(pwd) using app 'backend.app'..."
 # Execute the main container command using python -m flask from venv
 # Using exec means the Flask process replaces the shell script process
-exec /opt/venv/bin/python -m flask run
+exec /opt/venv/bin/python -m flask --app backend.app run


### PR DESCRIPTION
This commit aims to definitively resolve container startup issues related to Python imports and Flask application loading for both database migrations and running the application.

Changes:
-   **Containerfile**:
    - Ensures `ENV PYTHONPATH=/app` is set, allowing Python to find
      packages directly under `/app` (e.g., the `backend` package).
    - Sets a default `ENV FLASK_APP=backend.app`, suitable for when the
      application is run from the `/app` directory.

-   **scripts/entrypoint.sh**:
    - When running database migrations (`flask db upgrade`):
        - The script changes the current directory to `/app/backend`.
        - It now explicitly uses `/opt/venv/bin/python -m flask --app app db upgrade`.
          The `--app app` flag tells Flask to load `app.py` from the
          current directory (`/app/backend`). This avoids issues with
          nested package name resolution.
    - When running the application (`flask run`):
        - The script changes the current directory to `/app`.
        - It now explicitly uses `/opt/venv/bin/python -m flask --app backend.app run`.
          The `--app backend.app` flag, in conjunction with `PYTHONPATH=/app`,
          correctly loads `/app/backend/app.py`.

This precise specification of the Flask application context for each command should prevent previous import errors like "attempted relative import with no known parent package" and "Could not import 'backend.backend.app'".