### PR TITLE
feat: Implement dynamic feed updates and manual refresh

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -349,6 +349,26 @@ def mark_item_read(item_id):
 
 # --- Manual Feed Update Endpoint ---
 
+@app.route('/api/feeds/update-all', methods=['POST'])
+def api_update_all_feeds():
+    """
+    Triggers an update for all feeds in the system.
+    Returns the count of processed feeds and new items.
+    """
+    logger.info("Received request to update all feeds.")
+    try:
+        processed_count, new_items_count = update_all_feeds()
+        logger.info(f"All feeds update process completed. Processed: {processed_count}, New Items: {new_items_count}")
+        return jsonify({
+            'message': 'All feeds updated successfully.',
+            'feeds_processed': processed_count,
+            'new_items': new_items_count
+        }), 200
+    except Exception as e:
+        logger.error(f"Error during /api/feeds/update-all: {str(e)}", exc_info=True)
+        # Consistent error response with other parts of the API
+        return jsonify({'error': 'An error occurred while updating all feeds.'}), 500
+
 @app.route('/api/feeds/<int:feed_id>/update', methods=['POST'])
 def update_feed(feed_id):
     """Manually triggers an update check for a specific feed."""

--- a/backend/test_app.py
+++ b/backend/test_app.py
@@ -473,3 +473,52 @@ def test_get_non_existent_static_file(client):
     """Test GET /<path:filename> for a non-existent file."""
     response = client.get('/nonexistentfile.css')
     assert response.status_code == 404
+
+# --- Tests for POST /api/feeds/update-all ---
+
+@patch('backend.app.update_all_feeds')
+def test_update_all_feeds_success(mock_update_all_feeds, client):
+    """Test POST /api/feeds/update-all successfully."""
+    # Configure the mock to return a sample tuple
+    mock_update_all_feeds.return_value = (5, 10)  # 5 feeds processed, 10 new items
+
+    # Make a POST request to /api/feeds/update-all
+    response = client.post('/api/feeds/update-all')
+
+    # Assert that the response status code is 200
+    assert response.status_code == 200
+
+    # Assert that mock_update_all_feeds was called once
+    mock_update_all_feeds.assert_called_once()
+
+    # Parse the response JSON data
+    data = response.get_json()
+
+    # Assert the structure and content of the JSON response
+    assert data['message'] == 'All feeds updated successfully.'
+    assert data['feeds_processed'] == 5
+    assert data['new_items'] == 10
+
+@patch('backend.app.update_all_feeds')
+def test_update_all_feeds_exception(mock_update_all_feeds, client):
+    """Test POST /api/feeds/update-all when update_all_feeds raises an exception."""
+    # Configure the mock to raise an exception
+    mock_update_all_feeds.side_effect = Exception("Test update error")
+
+    # Make a POST request to /api/feeds/update-all
+    response = client.post('/api/feeds/update-all')
+
+    # Assert that the response status code is 500
+    assert response.status_code == 500
+
+    # Assert that mock_update_all_feeds was called once
+    mock_update_all_feeds.assert_called_once()
+
+    # Parse the response JSON data
+    data = response.get_json()
+
+    # Assert the error message in the JSON response
+    # Based on the endpoint's error handling:
+    # return jsonify({'error': 'An error occurred while updating all feeds.'}), 500
+    assert 'error' in data
+    assert data['error'] == 'An error occurred while updating all feeds.'

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,6 +21,7 @@
         <div id="add-feed-section">
             <input type="text" id="feed-url-input" placeholder="Enter feed URL">
             <button id="add-feed-button">Add Feed</button>
+            <button id="refresh-all-feeds-button">Refresh All Feeds</button>
         </div>
     </header>
     <main id="feed-grid">

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const addTabButton = document.getElementById('add-tab-button');
     const renameTabButton = document.getElementById('rename-tab-button');
     const deleteTabButton = document.getElementById('delete-tab-button');
+    const refreshAllFeedsButton = document.getElementById('refresh-all-feeds-button'); // Added
     
     // State variables
     let activeTabId = null; // ID of the currently selected tab
@@ -41,6 +42,47 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (e) {
             console.error('Error formatting date:', isoString, e);
             return 'Invalid date';
+        }
+    }
+
+    // --- Feed Refresh Logic ---
+
+    /** Handles the click event for the "Refresh All Feeds" button. */
+    async function handleRefreshAllFeeds() {
+        console.log("Refreshing all feeds...");
+        const originalButtonText = refreshAllFeedsButton.textContent;
+        refreshAllFeedsButton.disabled = true;
+        refreshAllFeedsButton.textContent = 'Refreshing...';
+
+        try {
+            const result = await fetchData('/api/feeds/update-all', { method: 'POST' });
+
+            if (result && result.message) {
+                alert(`Successfully refreshed all feeds.\nProcessed: ${result.feeds_processed}\nNew items: ${result.new_items}`);
+                console.log('All feeds refreshed:', result);
+                // If an active tab is set, reload its feeds to show new items
+                if (activeTabId) {
+                    // Stop current polling before manual refresh, then restart
+                    stopPolling();
+                    await loadFeedsForTab(activeTabId, false); // false to ensure grid is cleared and reloaded
+                    startPolling(); // Restart polling with potentially new data
+                }
+            } else if (result && result.error) {
+                // Handle cases where the API returns a JSON error object but not an HTTP error
+                alert(`Failed to refresh all feeds: ${result.error}`);
+                console.error('Error refreshing all feeds:', result.error);
+            } else if (!result) {
+                // fetchData already shows an alert for network/HTTP errors, so just log here
+                console.error('Failed to refresh all feeds. fetchData returned null.');
+            }
+        } catch (error) {
+            // This catch is mostly for unexpected errors in this function's logic,
+            // as fetchData handles its own errors including alerts.
+            console.error('Unexpected error in handleRefreshAllFeeds:', error);
+            alert('An unexpected error occurred while refreshing feeds.');
+        } finally {
+            refreshAllFeedsButton.disabled = false;
+            refreshAllFeedsButton.textContent = originalButtonText;
         }
     }
 
@@ -626,6 +668,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 handleAddFeed();
             }
         });
+        refreshAllFeedsButton.addEventListener('click', handleRefreshAllFeeds); // Added
 
         // Fetch initial tabs to start the application
         await initializeTabs();


### PR DESCRIPTION
This commit introduces two main enhancements:

1.  **Dynamic Feed Updates (Polling Refinement):**
    *   Reviewed and confirmed the frontend polling mechanism in `script.js` which periodically fetches new items for active feeds.
    *   The existing logic in `renderFeedWidget` correctly prepends new items to the display without a full page reload, fulfilling the dynamic update requirement from TODO.md (Phase 3).

2.  **Manual "Refresh All Feeds" Button:**
    *   Added a `POST /api/feeds/update-all` endpoint to `backend/app.py`. This endpoint calls the `update_all_feeds()` service function to refresh all configured feeds and returns a summary of the operation.
    *   Added corresponding backend tests for this new endpoint in `backend/test_app.py`, covering success and error scenarios.
    *   Integrated a "Refresh All Feeds" button into `frontend/index.html`.
    *   Implemented the frontend logic in `frontend/script.js` for this button. It calls the backend endpoint, displays a status message, and refreshes the current tab's view to display any newly fetched items.

The backend already had a scheduled job to update all feeds periodically. These changes ensure that the frontend can reflect these updates dynamically through polling and allows you to trigger a global refresh manually.