### PR TITLE
feat: Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Enable version updates for pip
+  - package-ecosystem: "pip"
+    directory: "/backend" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+    # Include a list of allowed updates
+    # to avoid breaking changes from major version updates
+    # For example, allow only patch and minor updates for requests
+    # allowed_updates:
+    #  - match:
+    #      dependency-name: "requests"
+    #      update-type: "semver:patch"
+    #  - match:
+    #      dependency-name: "requests"
+    #      update-type: "semver:minor"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of workflows
+    schedule:
+      interval: "daily"
+    target-branch: "main"


### PR DESCRIPTION
This commit introduces a Dependabot configuration file (.github/dependabot.yml) to automate dependency updates.

Dependabot is configured to:
- Check for Python (pip) dependency updates in the 'backend/' directory, targeting 'requirements.txt' and 'requirements-dev.txt'.
- Check for GitHub Actions updates in the root directory.
- Run daily checks for both ecosystems.
- Target the 'main' branch for pull requests.