### PR TITLE
Refactor Podman deployment to use Quadlet multi-file structure

### DIFF
--- a/pod/quadlet/sheepvibes-app.container
+++ b/pod/quadlet/sheepvibes-app.container
@@ -1,0 +1,24 @@
+# pod/quadlet/sheepvibes-app.container
+
+[Unit]
+Description=SheepVibes Application Container
+Requires=sheepvibes-db.volume
+After=sheepvibes-db.volume
+
+[Container]
+Pod=sheepvibespod.pod
+ContainerName=sheepvibes-app
+Image=ghcr.io/sheepdestroyer/sheepvibes:latest
+Volume=sheepvibes-db.volume:/app/data
+
+Environment=DATABASE_PATH=/app/data/sheepvibes.db
+Environment=CACHE_REDIS_URL=redis://localhost:6379/0
+Environment=FLASK_APP=backend.app
+Environment=PYTHONPATH=/app
+Environment=UPDATE_INTERVAL_MINUTES=15
+Environment=FLASK_RUN_HOST=0.0.0.0
+
+Restart=on-failure
+TimeoutStartSec=180
+# StartWithPod=true is the default when Pod= is specified.
+# No [Install] section needed if pod is the primary enabled unit.

--- a/pod/quadlet/sheepvibes-db.volume
+++ b/pod/quadlet/sheepvibes-db.volume
@@ -1,0 +1,10 @@
+# pod/quadlet/sheepvibes-db.volume
+
+[Unit]
+Description=Volume for SheepVibes Database
+
+[Volume]
+# VolumeName=sheepvibes-db # Optional: Default is systemd-sheepvibes-db
+
+[Install]
+WantedBy=default.target

--- a/pod/quadlet/sheepvibes-redis-data.volume
+++ b/pod/quadlet/sheepvibes-redis-data.volume
@@ -1,0 +1,10 @@
+# pod/quadlet/sheepvibes-redis-data.volume
+
+[Unit]
+Description=Volume for SheepVibes Redis Data
+
+[Volume]
+# VolumeName=sheepvibes-redis-data # Optional: Default is systemd-sheepvibes-redis-data
+
+[Install]
+WantedBy=default.target

--- a/pod/quadlet/sheepvibes-redis.container
+++ b/pod/quadlet/sheepvibes-redis.container
@@ -1,0 +1,17 @@
+# pod/quadlet/sheepvibes-redis.container
+
+[Unit]
+Description=SheepVibes Redis Container
+Requires=sheepvibes-redis-data.volume
+After=sheepvibes-redis-data.volume
+
+[Container]
+Pod=sheepvibespod.pod
+ContainerName=sheepvibes-redis
+Image=docker.io/redis:alpine
+Volume=sheepvibes-redis-data.volume:/data
+
+Restart=on-failure
+TimeoutStartSec=90
+# StartWithPod=true is the default when Pod= is specified.
+# No [Install] section needed if pod is the primary enabled unit.

--- a/pod/quadlet/sheepvibespod.pod
+++ b/pod/quadlet/sheepvibespod.pod
@@ -1,0 +1,11 @@
+# pod/quadlet/sheepvibespod.pod
+
+[Unit]
+Description=SheepVibes Application Pod
+# Let Quadlet handle network dependencies for user sessions automatically.
+
+[Pod]
+PublishPort=127.0.0.1:5000:5000
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
- Replaced monolithic sheepvibespod.pod with separate .pod, .container, and .volume Quadlet files in pod/quadlet/.
- Updated deploy_pod.sh to download and manage these new files.
- Modified deploy_pod.sh and README.md to reflect new service names, volume names, and deployment steps.
- Relies on Quadlet's default network dependency handling for user sessions.
- Provides improved diagnostic and verification steps in deploy_pod.sh and README.md.