### PR TITLE
Fix: Correct .container files for older Quadlet compatibility

### DIFF
--- a/pod/quadlet/sheepvibes-app.container
+++ b/pod/quadlet/sheepvibes-app.container
@@ -18,7 +18,8 @@ Environment=PYTHONPATH=/app
 Environment=UPDATE_INTERVAL_MINUTES=15
 Environment=FLASK_RUN_HOST=0.0.0.0
 
+# StartWithPod=true is the default when Pod= is specified.
+
+[Service]
 Restart=on-failure
 TimeoutStartSec=180
-# StartWithPod=true is the default when Pod= is specified.
-# No [Install] section needed if pod is the primary enabled unit.

--- a/pod/quadlet/sheepvibes-redis.container
+++ b/pod/quadlet/sheepvibes-redis.container
@@ -11,7 +11,8 @@ ContainerName=sheepvibes-redis
 Image=docker.io/redis:alpine
 Volume=sheepvibes-redis-data.volume:/data
 
+# StartWithPod=true is the default when Pod= is specified.
+
+[Service]
 Restart=on-failure
 TimeoutStartSec=90
-# StartWithPod=true is the default when Pod= is specified.
-# No [Install] section needed if pod is the primary enabled unit.


### PR DESCRIPTION
Moved Restart= and TimeoutStartSec= directives from the [Container] section to a [Service] section within sheepvibes-app.container and sheepvibes-redis.container.

This addresses an issue where an older version of the Quadlet generator on AlmaLinux 10 (RHEL 10 derivative) did not support these keys directly in the [Container] section, preventing the container services from being generated.