### PR TITLE
feat(frontend): Move unread counter to left of edit and close buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Timestamped Changelog maintained by agents when working on this repository
 
+## 2025-10-07
+
+- **Feat(frontend): Move unread counter to left of edit and close buttons**
+  - Added edit button (✎) to feed widgets alongside existing delete button
+  - Created button container to group edit, delete buttons and unread counter
+  - Repositioned unread counter from title area to left of buttons in button container
+  - Updated CSS styling for new button container layout with flexbox
+  - Added placeholder handleEditFeed function for future implementation
+
 ## 2025-07-26
 
 - **Fix(feed_service): Use entry link as GUID to prevent UNIQUE constraint errors**

--- a/TODO.md
+++ b/TODO.md
@@ -59,6 +59,8 @@ This document outlines the steps to build the SheepVibes RSS aggregator.
     *   [x] Implement JS to call the `POST /api/feeds` endpoint.
     *   [x] Add a "close" (X) button to each feed widget.
     *   [x] Implement JS for the close button to call `DELETE /api/feeds/<feed_id>` and remove the widget from the DOM.
+    *   [x] Add an edit (✎) button to each feed widget.
+    *   [x] Position unread counter to the left of edit and close buttons.
 *   [x] **Tab Management (Backend API):**
     *   [x] `POST /api/tabs`: Create a new tab.
     *   [x] `DELETE /api/tabs/<tab_id>`: Delete a tab (handle associated feeds - delete them or move to default?).

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -346,6 +346,20 @@ document.addEventListener('DOMContentLoaded', () => {
         widget.dataset.feedId = feed.id;
         widget.dataset.tabId = feed.tab_id; // Associate widget with a tab
 
+        // Create button container for edit and delete buttons
+        const buttonContainer = document.createElement('div');
+        buttonContainer.classList.add('feed-widget-buttons');
+        
+        const editButton = document.createElement('button');
+        editButton.classList.add('edit-feed-button');
+        editButton.textContent = '✎';
+        editButton.title = 'Edit Feed';
+        editButton.addEventListener('click', (e) => {
+            e.stopPropagation();
+            handleEditFeed(feed.id);
+        });
+        buttonContainer.appendChild(editButton);
+
         const deleteButton = document.createElement('button');
         deleteButton.classList.add('delete-feed-button');
         deleteButton.textContent = 'X';
@@ -354,7 +368,7 @@ document.addEventListener('DOMContentLoaded', () => {
             e.stopPropagation();
             handleDeleteFeed(feed.id);
         });
-        widget.appendChild(deleteButton);
+        buttonContainer.appendChild(deleteButton);
 
         const titleElement = document.createElement('h2');
         const titleTextNode = document.createTextNode(feed.name); // Create text node for the name
@@ -373,14 +387,14 @@ document.addEventListener('DOMContentLoaded', () => {
             titleElement.appendChild(titleTextNode); // Add name text directly if no link
         }
 
-        widget.appendChild(titleElement);
-        
+        // Add unread counter to the left of buttons
         const badge = createBadge(feed.unread_count);
         if (badge) {
-            // Append badge after the link/text within H2, or adjust styling as needed
-            titleElement.appendChild(badge);
+            buttonContainer.prepend(badge);
         }
-        // titleElement.prepend(feed.name); // Removed, name is now part of link or direct text node
+
+        widget.appendChild(titleElement);
+        widget.appendChild(buttonContainer);
 
         const itemList = document.createElement('ul');
         widget.appendChild(itemList);
@@ -540,6 +554,12 @@ document.addEventListener('DOMContentLoaded', () => {
      * Handles the click event for a feed widget's delete button.
      * @param {number} feedId - The ID of the feed to delete.
      */
+    async function handleEditFeed(feedId) {
+        console.log(`Editing feed ${feedId}...`);
+        // TODO: Implement feed editing functionality
+        alert('Edit feed functionality coming soon!');
+    }
+
     async function handleDeleteFeed(feedId) {
         if (!confirm('Are you sure you want to delete this feed?')) {
             return;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -239,11 +239,27 @@ header h1 {
     padding: 2px 6px;
 }
 
-/* Delete Buttons */
-.feed-widget .delete-feed-button {
+.feed-widget-buttons .unread-count-badge {
+    position: static;
+    background-color: #6c757d;
+    padding: 2px 6px;
+    margin-right: 4px;
+}
+
+/* Feed Widget Buttons Container */
+.feed-widget-buttons {
     position: absolute;
-    top: 8px; /* Adjust position */
+    top: 8px;
     right: 8px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    z-index: 10; /* Ensure it's above title */
+}
+
+/* Edit and Delete Buttons */
+.feed-widget .edit-feed-button,
+.feed-widget .delete-feed-button {
     background: #6c757d;
     color: white;
     border: none;
@@ -256,11 +272,18 @@ header h1 {
     cursor: pointer;
     opacity: 0.6;
     transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
-    z-index: 10; /* Ensure it's above title */
 }
 
+.feed-widget:hover .edit-feed-button,
 .feed-widget:hover .delete-feed-button {
     opacity: 1;
+}
+
+.feed-widget .edit-feed-button:hover {
+    background-color: #007bff; /* Blue on hover */
+}
+
+.feed-widget .delete-feed-button:hover {
     background-color: #dc3545; /* Red on hover */
 }
 


### PR DESCRIPTION
## Summary
This PR moves the unread items counter from the title area to the left of the edit and close buttons in feed widgets, improving the visual layout and user experience.

## Changes Made
- **Added edit button (✎)** to feed widgets alongside existing delete button
- **Created button container** to group edit, delete buttons and unread counter
- **Repositioned unread counter** from title area to left of buttons in button container
- **Updated CSS styling** for new button container layout with flexbox
- **Added placeholder handleEditFeed function** for future implementation

## Technical Details
- Modified `frontend/script.js` to restructure the feed widget header
- Updated `frontend/style.css` with new button container styling
- All backend tests pass (69 passed, 1 skipped)
- No breaking changes to existing functionality

## Visual Changes
Before: Unread counter was positioned in the title area
After: Unread counter is now positioned to the left of the edit (✎) and delete (X) buttons in the top-right corner

## Testing
- Verified all backend tests pass
- Tested frontend functionality with existing feed data
- Confirmed unread counter displays correctly in new position