### PR TITLE
🔒 Tighten OPML import file type validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** `feedparser` library relies on standard XML libraries which may be vulnerable to XXE (XML External Entity) attacks if not configured securely or if the environment defaults are insecure.
 **Learning:** Even if the current environment's Python version (e.g. 3.12) defaults to safe XML parsing, relying on implicit defaults is risky. Explicit validation using `defusedxml` is required for robust security.
 **Prevention:** Implemented a pre-validation step using `defusedxml.sax.parseString` to check for DTDs and entities before passing content to `feedparser`. This ensures XXE attacks are blocked regardless of the underlying parser's configuration.
+
+## 2026-02-05 - Strengthening OPML File Type Validation
+**Vulnerability:** Weak file type validation allowed .txt files for OPML imports, which could lead to processing of unintended file types or bypasses of security controls.
+**Learning:** Whitelists for file uploads should be as restrictive as possible. Including generic types like .txt in an XML-specific import path increases the attack surface unnecessarily.
+**Prevention:** Removed .txt from the allowed extensions for OPML imports. Validated with a regression test to ensure only .opml and .xml are accepted.

--- a/backend/blueprints/opml.py
+++ b/backend/blueprints/opml.py
@@ -81,7 +81,7 @@ def _validate_opml_file_request():
         return None, (jsonify({"error": "File object is empty"}), 400)
 
     # Basic security: check file extension
-    allowed_extensions = {".opml", ".xml", ".txt"}
+    allowed_extensions = {".opml", ".xml"}
     _, ext = os.path.splitext(opml_file.filename)
     if ext.lower() not in allowed_extensions:
         return None, (

--- a/backend/blueprints/opml.py
+++ b/backend/blueprints/opml.py
@@ -34,8 +34,8 @@ def _generate_opml_string(tabs=None):
 
     if tabs is None:
         # Eager load feeds to avoid N+1 queries
-        tabs = Tab.query.options(selectinload(
-            Tab.feeds)).order_by(Tab.order).all()
+        tabs = Tab.query.options(selectinload(Tab.feeds)).order_by(
+            Tab.order).all()
 
     for tab in tabs:
         # Skip tabs with no feeds
@@ -60,9 +60,8 @@ def _generate_opml_string(tabs=None):
                 feed_outline.set("htmlUrl", feed.site_link)
 
     # Convert the XML tree to a string
-    opml_string = ET.tostring(opml_element, encoding="utf-8", method="xml").decode(
-        "utf-8"
-    )
+    opml_string = ET.tostring(opml_element, encoding="utf-8",
+                              method="xml").decode("utf-8")
 
     feed_count = sum(len(tab.feeds) for tab in tabs)
     tab_count = sum(1 for tab in tabs if tab.feeds)
@@ -76,7 +75,8 @@ def _validate_opml_file_request():
         return None, (jsonify({"error": "No file part in the request"}), 400)
     opml_file = request.files["file"]
     if opml_file.filename == "":
-        return None, (jsonify({"error": "No file selected for uploading"}), 400)
+        return None, (jsonify({"error":
+                               "No file selected for uploading"}), 400)
     if not opml_file:
         return None, (jsonify({"error": "File object is empty"}), 400)
 
@@ -85,11 +85,10 @@ def _validate_opml_file_request():
     _, ext = os.path.splitext(opml_file.filename)
     if ext.lower() not in allowed_extensions:
         return None, (
-            jsonify(
-                {
-                    "error": f"Invalid file type. Allowed: {', '.join(allowed_extensions)}"
-                }
-            ),
+            jsonify({
+                "error":
+                f"Invalid file type. Allowed: {', '.join(allowed_extensions)}"
+            }),
             400,
         )
 
@@ -113,8 +112,8 @@ def import_opml():
     requested_tab_id_str = request.form.get("tab_id")
 
     # Call the service function
-    result, error_info = import_opml_service(
-        opml_file.stream, requested_tab_id_str)
+    result, error_info = import_opml_service(opml_file.stream,
+                                             requested_tab_id_str)
 
     if error_info:
         error_json, status_code = error_info
@@ -142,8 +141,7 @@ def export_opml():
 
     response = Response(opml_string, mimetype="application/xml")
     response.headers["Content-Disposition"] = (
-        'attachment; filename="sheepvibes_feeds.opml"'
-    )
+        'attachment; filename="sheepvibes_feeds.opml"')
 
     logger.info(
         "Successfully generated OPML export for %d feeds across %d tabs.",
@@ -178,12 +176,12 @@ def _get_autosave_directory():
                 abs_db_path = os.path.abspath(db_path)
                 data_dir = os.path.dirname(abs_db_path)
                 logger.debug(
-                    "Resolved autosave directory from SQLite path: %s", data_dir
-                )
+                    "Resolved autosave directory from SQLite path: %s",
+                    data_dir)
             except Exception:
                 logger.warning(
-                    "Could not resolve absolute path for SQLite DB: %s", db_path
-                )
+                    "Could not resolve absolute path for SQLite DB: %s",
+                    db_path)
 
     if not data_dir:
         # 3. Fall back to PROJECT_ROOT/data
@@ -193,8 +191,7 @@ def _get_autosave_directory():
 
     if not data_dir:
         logger.warning(
-            "Could not determine autosave directory. Skipping OPML autosave."
-        )
+            "Could not determine autosave directory. Skipping OPML autosave.")
         return None
 
     try:
@@ -235,8 +232,8 @@ def _write_atomically_with_lock(autosave_path, opml_string):
             try:
                 os.remove(temp_path)
             except OSError as e:
-                logger.warning(
-                    "Failed to remove temporary file %s: %s", temp_path, e)
+                logger.warning("Failed to remove temporary file %s: %s",
+                               temp_path, e)
     return False
 
 

--- a/tests/unit/test_opml_extension.py
+++ b/tests/unit/test_opml_extension.py
@@ -1,0 +1,30 @@
+import io
+import pytest
+from backend.app import app
+
+def test_opml_import_txt_disallowed(client):
+    """Test that .txt is now disallowed."""
+    url = "/api/opml/import"
+
+    data_txt = {"file": (io.BytesIO(b"dummy"), "test.txt")}
+    response = client.post(url, data=data_txt, content_type="multipart/form-data")
+    assert response.status_code == 400
+    assert "Invalid file type" in response.get_json()["error"]
+
+def test_opml_import_allowed_extensions(client, mocker):
+    """Test that .opml and .xml are allowed."""
+    url = "/api/opml/import"
+    mocker.patch("backend.blueprints.opml.import_opml_service", return_value=({"imported_count": 0}, None))
+
+    for ext in [".opml", ".xml"]:
+        data = {"file": (io.BytesIO(b"<opml></opml>"), f"test{ext}")}
+        response = client.post(url, data=data, content_type="multipart/form-data")
+        assert response.status_code == 200
+
+def test_opml_import_disallowed_extension(client):
+    """Test that other extensions are disallowed."""
+    url = "/api/opml/import"
+    data = {"file": (io.BytesIO(b"dummy"), "test.exe")}
+    response = client.post(url, data=data, content_type="multipart/form-data")
+    assert response.status_code == 400
+    assert "Invalid file type" in response.get_json()["error"]

--- a/tests/unit/test_opml_extension.py
+++ b/tests/unit/test_opml_extension.py
@@ -1,25 +1,39 @@
 import io
+
 import pytest
+
 from backend.app import app
+
 
 def test_opml_import_txt_disallowed(client):
     """Test that .txt is now disallowed."""
     url = "/api/opml/import"
 
     data_txt = {"file": (io.BytesIO(b"dummy"), "test.txt")}
-    response = client.post(url, data=data_txt, content_type="multipart/form-data")
+    response = client.post(url,
+                           data=data_txt,
+                           content_type="multipart/form-data")
     assert response.status_code == 400
     assert "Invalid file type" in response.get_json()["error"]
+
 
 def test_opml_import_allowed_extensions(client, mocker):
     """Test that .opml and .xml are allowed."""
     url = "/api/opml/import"
-    mocker.patch("backend.blueprints.opml.import_opml_service", return_value=({"imported_count": 0}, None))
+    mocker.patch(
+        "backend.blueprints.opml.import_opml_service",
+        return_value=({
+            "imported_count": 0
+        }, None),
+    )
 
     for ext in [".opml", ".xml"]:
         data = {"file": (io.BytesIO(b"<opml></opml>"), f"test{ext}")}
-        response = client.post(url, data=data, content_type="multipart/form-data")
+        response = client.post(url,
+                               data=data,
+                               content_type="multipart/form-data")
         assert response.status_code == 200
+
 
 def test_opml_import_disallowed_extension(client):
     """Test that other extensions are disallowed."""


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Removed `.txt` from the list of allowed file extensions for OPML imports in `backend/blueprints/opml.py`.

### ⚠️ Risk: The potential impact if left unfixed
Allowing generic `.txt` files for an XML-based import feature like OPML is a weak validation practice. It increases the attack surface and could potentially be used to bypass security controls or lead to unexpected behavior when processing files that are not valid OPML.

### 🛡️ Solution: How the fix addresses the vulnerability
The `allowed_extensions` whitelist now only includes `.opml` and `.xml`, which are the standard extensions for OPML files. This ensures that only relevant file types are passed to the parsing logic. A new regression test verifies that `.txt` files are rejected with a 400 error, while `.opml` and `.xml` files remain supported.

---
*PR created automatically by Jules for task [12261617681293711460](https://jules.google.com/task/12261617681293711460) started by @sheepdestroyer*

## Summary by Sourcery

Tighten OPML import file type validation to only accept XML-based formats and document the security rationale.

Bug Fixes:
- Restrict OPML import allowed extensions to .opml and .xml, disallowing .txt and other non-XML types to reduce attack surface.

Documentation:
- Extend the security sentinel documentation to capture the OPML file type validation hardening and its rationale.

Tests:
- Add regression tests covering acceptance of .opml and .xml files and rejection of .txt and other disallowed extensions for the OPML import endpoint.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed `.txt` from allowed extensions for OPML imports in `opml.py`, ensuring only `.opml` and `.xml` are accepted, with tests added in `test_opml_extension.py`.
> 
>   - **Behavior**:
>     - Removed `.txt` from allowed extensions in `_validate_opml_file_request()` in `opml.py`.
>     - Only `.opml` and `.xml` files are now accepted for OPML imports.
>   - **Tests**:
>     - Added `test_opml_import_txt_disallowed()` in `test_opml_extension.py` to verify `.txt` files are rejected.
>     - Added `test_opml_import_allowed_extensions()` to ensure `.opml` and `.xml` files are accepted.
>     - Added `test_opml_import_disallowed_extension()` to confirm other extensions are rejected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2FSheepVibes&utm_source=github&utm_medium=referral)<sup> for 691981ca7d2a31aad512e07fa0dba500e7fd61e1. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened OPML file type validation to only accept .opml and .xml files, rejecting unsupported formats
  * Feeds now appear in deterministic order in OPML exports for consistency

* **Tests**
  * Added unit tests validating OPML import file type validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->