### PR TITLE
Fix middle-click mark as read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Timestamped Changelog maintained by agents when working on this repository
 
+## 2026-02-22
+
+- **Fix: Middle-click to mark as read**
+  - Added `auxclick` event listener to feed item links in `frontend/js/ui.js` to ensure items are marked as read when opened via middle-click.
+
 ## 2026-01-29
 
 - **Feat: Robust OPML Import & Feed Refresh Progress**

--- a/TODO.md
+++ b/TODO.md
@@ -77,6 +77,7 @@ This document outlines the steps to build the SheepVibes RSS aggregator.
     *   [x] Add `is_read` flag to `FeedItems` model (default: false).
     *   [x] Add API endpoint `POST /api/items/<item_id>/read` or similar.
     *   [x] Update frontend to mark items visually and call the API (e.g., on click, or mark all visible as read).
+    *   [x] Fix middle-click not marking items as read by adding `auxclick` listener.
     *   [x] Update backend to calculate unread counts per feed/tab.
     *   [x] Display unread counts in the UI (widgets, tabs).
 

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -55,6 +55,11 @@ function createFeedItemElement(item, clickHandler) {
     link.target = '_blank';
     link.rel = 'noopener noreferrer';
     link.addEventListener('click', () => clickHandler(listItem));
+    link.addEventListener('auxclick', (event) => {
+        if (event.button === 1) {
+            clickHandler(listItem);
+        }
+    });
     listItem.appendChild(link);
 
     const timestamp = document.createElement('span');


### PR DESCRIPTION
Middle-clicking a feed item link now correctly marks it as read in the UI and backend, even if the link is opened in a background tab. This was achieved by adding an `auxclick` event listener to the item links in `frontend/js/ui.js`.

Fixes #322

---
*PR created automatically by Jules for task [16996417918374913839](https://jules.google.com/task/16996417918374913839) started by @sheepdestroyer*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `auxclick` event listener to mark feed items as read on middle-click in `frontend/js/ui.js`.
> 
>   - **Behavior**:
>     - Added `auxclick` event listener to feed item links in `frontend/js/ui.js` to mark items as read when opened via middle-click.
>   - **Documentation**:
>     - Updated `CHANGELOG.md` to include the fix for middle-click marking as read.
>     - Updated `TODO.md` to mark the task of fixing middle-click as complete.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2FSheepVibes&utm_source=github&utm_medium=referral)<sup> for cb4a65015b3a5f83c5c95a73263927cee99e11b6. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

## Summary by Sourcery

Ensure feed items are marked as read when opened via middle-click and document the change.

Bug Fixes:
- Fix feed items not being marked as read when opened via middle-click by handling auxiliary click events.

Documentation:
- Document the middle-click mark-as-read fix in the changelog and mark the related TODO item as complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Middle-clicking feed item links now marks them as read, providing an alternative interaction method alongside standard left-click behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->