### PR TITLE
⚡ Bolt: Optimize OPML import single-column query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2026-02-14 - Optimized Tab.to_dict serialization
 **Learning:** `Tab.to_dict()` triggered a separate SQL query for unread counts, causing N+1 issues when serializing lists of tabs (e.g. in `get_tabs`).
 **Action:** Implemented the same pattern as `Feed.to_dict()`: accept an optional `unread_count` parameter. Updated `get_tabs` to pre-calculate counts in a single query and pass them to `to_dict`.
+
+## 2026-03-20 - Optimize single column extractions
+**Learning:** Extracting a single column (e.g., `Feed.url`) from the database using `Feed.query.all()` instantiates complete ORM objects which wastes CPU and memory overhead.
+**Action:** Use `Feed.query.with_entities(Feed.url).all()` instead of `Feed.query.all()` when only extracting a single column.

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -619,7 +619,10 @@ def import_opml(opml_file_stream, requested_tab_id_str):
         return result, None
 
     # Optimization: Only fetch the 'url' column to avoid instantiating full Feed ORM objects
-    all_existing_feed_urls_set = {row[0] for row in Feed.query.with_entities(Feed.url).all()}
+    all_existing_feed_urls_set = {
+        row[0]
+        for row in Feed.query.with_entities(Feed.url).all()
+    }
 
     # Announce start
     announcer.announce(

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -618,7 +618,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
         )
         return result, None
 
-    all_existing_feed_urls_set = {feed.url for feed in Feed.query.all()}
+    # Optimization: Only fetch the 'url' column to avoid instantiating full Feed ORM objects
+    all_existing_feed_urls_set = {row[0] for row in Feed.query.with_entities(Feed.url).all()}
 
     # Announce start
     announcer.announce(


### PR DESCRIPTION
💡 **What**: Refactored the collection of existing feed URLs during OPML imports in `backend/feed_service.py`.
🎯 **Why**: Using `Feed.query.all()` instantiated the full `Feed` ORM objects just to extract their `.url` properties. `Feed.query.with_entities(Feed.url).all()` avoids this overhead by extracting only the requested column as tuples.
📊 **Impact**: Reduces CPU and memory usage significantly, particularly for databases with a large number of feeds.
🔬 **Measurement**: Ran `pytest tests/unit/test_opml_import.py` to ensure the logic remained correct, along with full test suite validation.

---
*PR created automatically by Jules for task [8438835086510532711](https://jules.google.com/task/8438835086510532711) started by @sheepdestroyer*

## Summary by Sourcery

Optimize OPML import by reducing overhead when loading existing feed URLs.

Enhancements:
- Limit OPML import feed URL lookup to a single-column query to avoid instantiating full Feed ORM objects and improve performance.

Documentation:
- Document the single-column query optimization and its motivation in the Bolt engineering notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database query performance during OPML import operations
  * Updated agent-tools dependency to latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->