### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix XSS Risk by Removing innerHTML

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -172,7 +172,9 @@ async function loadFeedsForTab(tabId) {
             const msg = document.createElement('div');
             msg.className = 'feed-widget empty-tab-message'; // Reuse class but add distinct marker
             msg.dataset.tabId = tabId;
-            msg.innerHTML = '<p>No feeds found for this tab. Add one using the form above!</p>';
+            const p = document.createElement('p');
+            p.textContent = 'No feeds found for this tab. Add one using the form above!';
+            msg.appendChild(p);
             feedGrid.appendChild(msg);
         }
         loadedTabs.add(tabId);

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -155,7 +155,9 @@ export function createFeedWidget(feed, callbacks) {
         });
         itemList.appendChild(fragment);
     } else {
-        itemList.innerHTML = '<li>No items found for this feed.</li>';
+        const li = document.createElement('li');
+        li.textContent = 'No items found for this feed.';
+        itemList.appendChild(li);
     }
 
     // Programmatically trigger a scroll event to handle cases where the initial
@@ -196,12 +198,20 @@ export function renderTabs(tabs, activeTabId, callbacks) {
     const renameTabButton = document.getElementById('rename-tab-button');
     const deleteTabButton = document.getElementById('delete-tab-button');
 
-    tabsContainer.innerHTML = '';
+    tabsContainer.textContent = '';
     if (!tabs || tabs.length === 0) {
-        tabsContainer.innerHTML = '<span>No tabs found.</span>';
+        const span = document.createElement('span');
+        span.textContent = 'No tabs found.';
+        tabsContainer.appendChild(span);
+
         renameTabButton.disabled = true;
         deleteTabButton.disabled = true;
-        feedGrid.innerHTML = '<p>Create a tab to get started!</p>';
+
+        feedGrid.textContent = '';
+        const p = document.createElement('p');
+        p.textContent = 'Create a tab to get started!';
+        feedGrid.appendChild(p);
+
         return { activeTabId: null };
     }
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix XSS Risk by Removing innerHTML
🚨 Severity: MEDIUM
💡 Vulnerability: The frontend code used `innerHTML` to inject DOM elements (`app.js`, `ui.js`). While the immediate injected content was static text, using `innerHTML` is an anti-pattern that creates a Cross-Site Scripting (XSS) sink. Future modifications that interpolate user data into these strings would immediately introduce a critical vulnerability.
🎯 Impact: If exploited by future refactoring, an attacker could inject malicious scripts into the application, potentially stealing user sessions, bypassing CSRF, or performing actions on the user's behalf.
🔧 Fix: Replaced all instances of `innerHTML` with safe DOM manipulation techniques (`document.createElement`, `textContent`, and `appendChild`).
✅ Verification: Tested the application locally, created frontend verification screenshots to confirm tabs empty states still render exactly as intended. Ran pytest on the backend to ensure no regressions.

---
*PR created automatically by Jules for task [3029414330310210208](https://jules.google.com/task/3029414330310210208) started by @sheepdestroyer*

## Summary by Sourcery

Bug Fixes:
- Eliminate uses of innerHTML in feed and tab empty-state rendering to remove an XSS sink in the frontend UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal DOM construction methods in feed and tab management components.
  * Replaced HTML string assignments with explicit element creation for improved maintainability.

* **Chores**
  * Updated agent-tools submodule reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->