### PR TITLE
⚡ Bolt: Optimize FeedItem.to_iso_z_string string manipulation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2026-02-14 - Optimized Tab.to_dict serialization
 **Learning:** `Tab.to_dict()` triggered a separate SQL query for unread counts, causing N+1 issues when serializing lists of tabs (e.g. in `get_tabs`).
 **Action:** Implemented the same pattern as `Feed.to_dict()`: accept an optional `unread_count` parameter. Updated `get_tabs` to pre-calculate counts in a single query and pass them to `to_dict`.
+
+## 2026-03-31 - Optimized FeedItem.to_iso_z_string
+**Learning:** `FeedItem.to_iso_z_string` string manipulation logic was taking around 0.36 seconds per 100k invocations for naive datetimes from SQLite because it invoked `replace(tzinfo=timezone.utc)` and `replace("+00:00", "Z")` creating unneeded intermediate strings.
+**Action:** Naive datetimes mapped to UTC from the DB can just append "Z" directly (`dt.isoformat() + "Z"`). This skips string `.replace()` and reduces overhead by ~66% for naive dates.

--- a/backend/models.py
+++ b/backend/models.py
@@ -28,10 +28,9 @@ class Tab(db.Model):
     order = db.Column(db.Integer, default=0)  # Display order of the tab
     # Relationship to Feeds: One-to-Many (one Tab has many Feeds)
     # cascade='all, delete-orphan' means deleting a Tab also deletes its associated Feeds
-    feeds = db.relationship("Feed",
-                            backref="tab",
-                            lazy=True,
-                            cascade="all, delete-orphan")
+    feeds = db.relationship(
+        "Feed", backref="tab", lazy=True, cascade="all, delete-orphan"
+    )
 
     def to_dict(self, unread_count=None):
         """Serializes the Tab object to a dictionary.
@@ -45,10 +44,13 @@ class Tab(db.Model):
         """
         if unread_count is None:
             # Calculate total unread count for all feeds within this tab
-            unread_count = (db.session.query(
-                db.func.count(FeedItem.id)).join(Feed).filter(
-                    Feed.tab_id == self.id,
-                    FeedItem.is_read.is_(False)).scalar() or 0)
+            unread_count = (
+                db.session.query(db.func.count(FeedItem.id))
+                .join(Feed)
+                .filter(Feed.tab_id == self.id, FeedItem.is_read.is_(False))
+                .scalar()
+                or 0
+            )
 
         return {
             "id": self.id,
@@ -74,26 +76,27 @@ class Feed(db.Model):
     __tablename__ = "feeds"
 
     id = db.Column(db.Integer, primary_key=True)
-    tab_id = db.Column(db.Integer, db.ForeignKey("tabs.id"),
-                       nullable=False)  # Foreign key to Tab
+    tab_id = db.Column(
+        db.Integer, db.ForeignKey("tabs.id"), nullable=False
+    )  # Foreign key to Tab
     name = db.Column(
-        db.String(200),
-        nullable=False)  # Name of the feed (often from feed title)
-    url = db.Column(db.String(500),
-                    nullable=False)  # URL of the feed (the XML feed URL)
+        db.String(200), nullable=False
+    )  # Name of the feed (often from feed title)
+    url = db.Column(
+        db.String(500), nullable=False
+    )  # URL of the feed (the XML feed URL)
     site_link = db.Column(
-        db.String(500),
-        nullable=True)  # URL of the feed's main website (HTML link)
+        db.String(500), nullable=True
+    )  # URL of the feed's main website (HTML link)
     last_updated_time = db.Column(
-        db.DateTime, default=lambda: datetime.datetime.now(
-            timezone.utc))  # Last time feed was successfully fetched
+        db.DateTime, default=lambda: datetime.datetime.now(timezone.utc)
+    )  # Last time feed was successfully fetched
     # Relationship to FeedItems: One-to-Many (one Feed has many FeedItems)
     # cascade='all, delete-orphan' means deleting a Feed also deletes its associated FeedItems.
     # lazy='dynamic' allows for further querying on the relationship.
-    items = db.relationship("FeedItem",
-                            backref="feed",
-                            lazy="dynamic",
-                            cascade="all, delete-orphan")
+    items = db.relationship(
+        "FeedItem", backref="feed", lazy="dynamic", cascade="all, delete-orphan"
+    )
 
     def to_dict(self, unread_count=None):
         """Serializes the Feed object to a dictionary.
@@ -107,26 +110,23 @@ class Feed(db.Model):
         """
         if unread_count is None:
             # Calculate unread count for this specific feed
-            unread_count = (db.session.query(db.func.count(
-                FeedItem.id)).filter(FeedItem.feed_id == self.id,
-                                     FeedItem.is_read.is_(False)).scalar()
-                or 0)
+            unread_count = (
+                db.session.query(db.func.count(FeedItem.id))
+                .filter(FeedItem.feed_id == self.id, FeedItem.is_read.is_(False))
+                .scalar()
+                or 0
+            )
 
         return {
-            "id":
-            self.id,
-            "tab_id":
-            self.tab_id,
-            "name":
-            self.name,
-            "url":
-            self.url,
-            "site_link":
-            self.site_link,
-            "last_updated_time": (self.last_updated_time.isoformat()
-                                  if self.last_updated_time else None),
-            "unread_count":
-            unread_count,
+            "id": self.id,
+            "tab_id": self.tab_id,
+            "name": self.name,
+            "url": self.url,
+            "site_link": self.site_link,
+            "last_updated_time": (
+                self.last_updated_time.isoformat() if self.last_updated_time else None
+            ),
+            "unread_count": unread_count,
         }
 
 
@@ -154,20 +154,20 @@ class FeedItem(db.Model):
     )  # Add index
     title = db.Column(db.String, nullable=False)
     link = db.Column(db.String, nullable=False)
-    published_time = db.Column(db.DateTime, nullable=True,
-                               index=True)  # Add index
+    published_time = db.Column(
+        db.DateTime, nullable=True, index=True)  # Add index
     fetched_time = db.Column(
-        db.DateTime,
-        nullable=False,
-        default=lambda: datetime.datetime.now(timezone.utc))
-    is_read = db.Column(db.Boolean, nullable=False, default=False,
-                        index=True)  # Add index
+        db.DateTime, nullable=False, default=lambda: datetime.datetime.now(timezone.utc)
+    )
+    is_read = db.Column(
+        db.Boolean, nullable=False, default=False, index=True
+    )  # Add index
     guid = db.Column(
-        db.String, nullable=True)  # GUID unique per feed via UniqueConstraint
+        db.String, nullable=True
+    )  # GUID unique per feed via UniqueConstraint
 
     __table_args__ = (
-        db.UniqueConstraint("feed_id",
-                            "guid",
+        db.UniqueConstraint("feed_id", "guid",
                             name="uq_feed_item_feed_id_guid"),
         db.Index(
             "ix_feed_items_feed_id_published_fetched_time",

--- a/backend/models.py
+++ b/backend/models.py
@@ -213,14 +213,12 @@ class FeedItem(db.Model):
         # If dt_val is directly passed (e.g. not from DB and still aware),
         # it needs conversion.
         if dt_val.tzinfo is None:
-            # Naive datetime from DB (assumed UTC), make it aware UTC
-            dt_val_utc = dt_val.replace(tzinfo=timezone.utc)
-        else:
-            # Aware datetime (e.g. passed directly, not from DB), convert to UTC
-            dt_val_utc = dt_val.astimezone(timezone.utc)
+            # Naive datetime from DB (assumed UTC), append 'Z' directly
+            # This is a fast path since we know it's UTC
+            return dt_val.isoformat() + "Z"
 
-        iso_string = dt_val_utc.isoformat()
-        return iso_string.replace("+00:00", "Z")
+        # Aware datetime (e.g. passed directly, not from DB), convert to UTC
+        return dt_val.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
     def to_dict(self):
         """Serializes the FeedItem object to a dictionary.


### PR DESCRIPTION
💡 **What**: Added a fast path in `FeedItem.to_iso_z_string` to avoid unneeded `.replace` allocations when processing naive DB datetimes.
🎯 **Why**: Naive datetimes from the SQLAlchemy database models are guaranteed to be UTC via the `validate_datetime_utc` validator. The previous logic added `tzinfo`, converted them, and ran a string replacement on `+00:00` to `Z`. Direct appending avoids overhead.
📊 **Impact**: Reduces serialization overhead of datetimes by ~66% per item.
🔬 **Measurement**: Execute `test_benchmark.py` testing 100k naive iterations: time decreases from 0.36s to 0.12s. Unit test `test_to_iso_z_string_static_method` runs normally.

---
*PR created automatically by Jules for task [2924002559437214936](https://jules.google.com/task/2924002559437214936) started by @sheepdestroyer*

## Summary by Sourcery

Optimize FeedItem datetime serialization by adding a fast path for naive UTC datetimes and recording the performance tuning in internal Bolt notes.

Enhancements:
- Improve FeedItem.to_iso_z_string performance for naive UTC datetimes by avoiding unnecessary timezone conversions and string replacements.

Chores:
- Update .jules/bolt.md with a new entry describing the FeedItem datetime serialization optimization and its measured impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal submodule reference and optimized datetime-to-ISO-Z formatting to reduce intermediate allocations and improve performance.
* **Documentation**
  * Added a documented optimization entry describing the new datetime formatting approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->