### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** `feedparser` library relies on standard XML libraries which may be vulnerable to XXE (XML External Entity) attacks if not configured securely or if the environment defaults are insecure.
 **Learning:** Even if the current environment's Python version (e.g. 3.12) defaults to safe XML parsing, relying on implicit defaults is risky. Explicit validation using `defusedxml` is required for robust security.
 **Prevention:** Implemented a pre-validation step using `defusedxml.sax.parseString` to check for DTDs and entities before passing content to `feedparser`. This ensures XXE attacks are blocked regardless of the underlying parser's configuration.
+
+## 2026-01-26 - Weak File Type Validation in OPML Import
+**Vulnerability:** Weak File Type Validation allowing `.txt` files to be uploaded as OPML.
+**Learning:** `backend/blueprints/opml.py` explicitly allowed `.txt` extensions in the `_validate_opml_file_request` method, which is not an expected format for OPML/XML files. While perhaps low-severity unless files are served directly, it breaks the principle of least privilege for file types.
+**Prevention:** Hardened validation by strictly checking for `.opml` and `.xml` extensions, and created a specific regression test `test_import_opml_txt_file_rejected`.

--- a/backend/blueprints/opml.py
+++ b/backend/blueprints/opml.py
@@ -88,7 +88,7 @@ def _validate_opml_file_request():
         return None, (jsonify({"error": "File object is empty"}), 400)
 
     # Basic security: check file extension
-    allowed_extensions = (".opml", ".xml", ".txt")
+    allowed_extensions = (".opml", ".xml")
     _, ext = os.path.splitext(opml_file.filename)
     if ext.lower() not in allowed_extensions:
         err_msg = f"Invalid file type. Allowed: {', '.join(allowed_extensions)}"

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1710,6 +1710,16 @@ def test_import_opml_empty_filename(client):
     assert "No file selected" in response.json["error"]
 
 
+def test_import_opml_txt_file_rejected(client):
+    """Test POST /api/opml/import rejects .txt files to prevent weak validation."""
+    opml_file = (io.BytesIO(b"dummy content"), "test.txt")
+    response = client.post("/api/opml/import",
+                           data={"file": opml_file},
+                           content_type="multipart/form-data")
+    assert response.status_code == 400
+    assert "Invalid file type. Allowed: .opml, .xml" in response.json["error"]
+
+
 def test_import_opml_malformed_xml(client):
     """Test POST /api/opml/import with malformed XML."""
     with app.app_context():  # Ensure a tab exists


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: Weak file type validation in OPML import endpoint allowing `.txt` files.
🎯 Impact: While likely low impact as files are parsed in memory, allowing unintended file extensions violates defense-in-depth and the principle of least privilege.
🔧 Fix: Removed `.txt` from the `allowed_extensions` list in `backend/blueprints/opml.py`.
✅ Verification: Added a regression test `test_import_opml_txt_file_rejected` in `tests/unit/test_app.py` and ran the full test suite.

---
*PR created automatically by Jules for task [12120127088378462380](https://jules.google.com/task/12120127088378462380) started by @sheepdestroyer*

## Summary by Sourcery

Tighten OPML import file-type validation to exclude non-OPML/XML uploads and record the change in security documentation.

Bug Fixes:
- Reject .txt uploads in the OPML import endpoint to prevent weak file-type validation.

Documentation:
- Extend Sentinel security notes with an entry describing the OPML file-type validation hardening and its rationale.

Tests:
- Add a regression test ensuring .txt files are rejected by the OPML import endpoint.

Chores:
- Add a placeholder agent-tools file to the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved OPML import file validation to restrict accepted file types to `.opml` and `.xml` extensions, preventing unintended file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->