### PR TITLE
⚡ Bolt: Optimize OPML Feed Fetching via Single-Column Retrieval

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2026-02-14 - Optimized Tab.to_dict serialization
 **Learning:** `Tab.to_dict()` triggered a separate SQL query for unread counts, causing N+1 issues when serializing lists of tabs (e.g. in `get_tabs`).
 **Action:** Implemented the same pattern as `Feed.to_dict()`: accept an optional `unread_count` parameter. Updated `get_tabs` to pre-calculate counts in a single query and pass them to `to_dict`.
+
+## 2026-04-02 - High-performance single-column retrieval avoiding ORM instantiation overhead
+**Learning:** For high-performance single-column retrieval (e.g., getting all Feed URLs during OPML imports), using `db.session.query(Model.column).all()` avoids the significant memory and CPU overhead of instantiating full SQLAlchemy ORM objects.
+**Action:** Use a query like `{url for url, in db.session.query(Feed.url).all()}` which directly returns a list of tuples instead of full objects.

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -618,7 +618,7 @@ def import_opml(opml_file_stream, requested_tab_id_str):
         )
         return result, None
 
-    all_existing_feed_urls_set = {feed.url for feed in Feed.query.all()}
+    all_existing_feed_urls_set = {url for url, in db.session.query(Feed.url).all()}
 
     # Announce start
     announcer.announce(


### PR DESCRIPTION
Replaced `Feed.query.all()` with `db.session.query(Feed.url).all()` in `import_opml` to significantly reduce memory and CPU overhead.

💡 What: The `import_opml` function was fetching full SQLAlchemy ORM objects for every feed just to extract the `url` property for duplicate checking. By changing the query to explicitly select only the `url` column, SQLAlchemy returns a list of lightweight tuples.
🎯 Why: Instantiating full ORM models incurs substantial memory allocation and CPU overhead (deserialization, state tracking). This micro-optimization directly avoids the unnecessary load during high-volume OPML imports.
📊 Impact: Reduces memory footprint and query time during OPML import process linearly with the number of feeds currently in the database.
🔬 Measurement: `PYTHONPATH=. pytest tests/unit/` ensures identical functionality. Code inspection and SQL log evaluation confirm identical results with reduced payload and model overhead.

---
*PR created automatically by Jules for task [10288816352024537796](https://jules.google.com/task/10288816352024537796) started by @sheepdestroyer*

## Summary by Sourcery

Optimize OPML import feed URL retrieval to reduce ORM overhead and improve performance during high-volume imports.

Enhancements:
- Use a single-column SQLAlchemy query to fetch existing feed URLs without instantiating full Feed ORM objects.
- Document the single-column retrieval pattern and its performance benefits in the bolt engineering notes.