### PR TITLE
⚡ Bolt: Optimize bulk cache invalidation for updated feeds

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2026-02-14 - Optimized Tab.to_dict serialization
 **Learning:** `Tab.to_dict()` triggered a separate SQL query for unread counts, causing N+1 issues when serializing lists of tabs (e.g. in `get_tabs`).
 **Action:** Implemented the same pattern as `Feed.to_dict()`: accept an optional `unread_count` parameter. Updated `get_tabs` to pre-calculate counts in a single query and pass them to `to_dict`.
+
+## 2026-02-15 - Optimized bulk cache invalidation
+**Learning:** `api_update_all_feeds` was invalidating the cache for each affected tab individually using `cache.set()`, resulting in N round-trips to the cache backend (Redis) when multiple tabs were updated.
+**Action:** Created `invalidate_multiple_tabs_cache` using `cache.get_many()` and `cache.set_many()` to perform bulk version increments in a single round-trip, significantly reducing overhead for system-wide feed updates.

--- a/backend/blueprints/feeds.py
+++ b/backend/blueprints/feeds.py
@@ -4,7 +4,11 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
-from ..cache_utils import invalidate_tab_feeds_cache, invalidate_tabs_cache, invalidate_multiple_tabs_cache
+from ..cache_utils import (
+    invalidate_multiple_tabs_cache,
+    invalidate_tab_feeds_cache,
+    invalidate_tabs_cache,
+)
 from ..constants import (
     DEFAULT_FEED_ITEMS_LIMIT,
     DEFAULT_PAGINATION_LIMIT,
@@ -43,7 +47,8 @@ def add_feed():
         default_tab = Tab.query.order_by(Tab.order).first()
         if not default_tab:
             # Cannot add feed if no tabs exist
-            return jsonify({"error": "Cannot add feed: No default tab found"}), 400
+            return jsonify({"error":
+                            "Cannot add feed: No default tab found"}), 400
         tab_id = default_tab.id
     else:
         # Verify the provided tab_id exists
@@ -71,8 +76,7 @@ def add_feed():
         )
     else:
         feed_name = parsed_feed.feed.get(
-            "title", feed_url
-        )  # Use URL as fallback if title missing
+            "title", feed_url)  # Use URL as fallback if title missing
         site_link = parsed_feed.feed.get("link")  # Get the website link
 
     try:
@@ -109,7 +113,8 @@ def add_feed():
         if num_new_items > 0:
             invalidate_tab_feeds_cache(tab_id)
         else:
-            invalidate_tabs_cache()  # At least invalidate for unread count change potential
+            invalidate_tabs_cache(
+            )  # At least invalidate for unread count change potential
 
         logger.info(
             "Added new feed '%s' with id %s to tab %s.",
@@ -128,7 +133,9 @@ def add_feed():
             exc_info=True,
         )
         return (
-            jsonify({"error": "An internal error occurred while adding the feed."}),
+            jsonify(
+                {"error":
+                 "An internal error occurred while adding the feed."}),
             500,
         )
 
@@ -158,7 +165,8 @@ def delete_feed(feed_id):
             feed_id,
         )
         # OK
-        return jsonify({"message": f"Feed {feed_id} deleted successfully"}), 200
+        return jsonify({"message":
+                        f"Feed {feed_id} deleted successfully"}), 200
     except Exception as e:
         db.session.rollback()
         logger.error(
@@ -168,8 +176,10 @@ def delete_feed(feed_id):
             exc_info=True,
         )
         return (
-            jsonify(
-                {"error": "An internal error occurred while deleting the feed."}),
+            jsonify({
+                "error":
+                "An internal error occurred while deleting the feed."
+            }),
             500,
         )
 
@@ -189,18 +199,15 @@ def update_feed_url(feed_id):
 
     data = request.get_json()
     # Validate input
-    if (
-        not data
-        or "url" not in data
-        or not (isinstance(data["url"], str) and data["url"].strip())
-    ):
+    if (not data or "url" not in data
+            or not (isinstance(data["url"], str) and data["url"].strip())):
         return jsonify({"error": "Missing or invalid feed URL"}), 400
 
     new_url = data["url"].strip()
 
     # Check if the new URL is already used by another feed
-    existing_feed = Feed.query.filter(
-        Feed.id != feed_id, Feed.url == new_url).first()
+    existing_feed = Feed.query.filter(Feed.id != feed_id,
+                                      Feed.url == new_url).first()
     if existing_feed:
         return (
             jsonify({"error": f"Feed with URL {new_url} already exists"}),
@@ -215,11 +222,8 @@ def update_feed_url(feed_id):
 
         if custom_name:
             new_name = custom_name
-            new_site_link = (
-                parsed_feed.feed.get("link")
-                if parsed_feed and parsed_feed.feed
-                else None
-            )
+            new_site_link = (parsed_feed.feed.get("link")
+                             if parsed_feed and parsed_feed.feed else None)
         elif not parsed_feed or not parsed_feed.feed:
             # If fetch fails and no custom name provided, use the URL as the name
             new_name = new_url
@@ -230,8 +234,7 @@ def update_feed_url(feed_id):
             )
         else:
             new_name = parsed_feed.feed.get(
-                "title", new_url
-            )  # Use URL as fallback if title missing
+                "title", new_url)  # Use URL as fallback if title missing
             new_site_link = parsed_feed.feed.get(
                 "link")  # Get the website link
 
@@ -278,10 +281,9 @@ def update_feed_url(feed_id):
         feed_data = feed.to_dict()
         # Include only recent feed items in the response (limit to DEFAULT_FEED_ITEMS_LIMIT)
         feed_data["items"] = [
-            item.to_dict()
-            for item in feed.items.order_by(
-                FeedItem.published_time.desc().nullslast(), FeedItem.fetched_time.desc()
-            ).limit(DEFAULT_FEED_ITEMS_LIMIT)
+            item.to_dict() for item in feed.items.order_by(
+                FeedItem.published_time.desc().nullslast(),
+                FeedItem.fetched_time.desc()).limit(DEFAULT_FEED_ITEMS_LIMIT)
         ]
         return jsonify(feed_data), 200  # OK
 
@@ -289,8 +291,10 @@ def update_feed_url(feed_id):
         db.session.rollback()
         logger.error("Error updating feed %s: %s", feed_id, e, exc_info=True)
         return (
-            jsonify(
-                {"error": "An internal error occurred while updating the feed."}),
+            jsonify({
+                "error":
+                "An internal error occurred while updating the feed."
+            }),
             500,
         )
 
@@ -311,38 +315,41 @@ def api_update_all_feeds():
             new_items_count,
         )
         if new_items_count > 0 and affected_tab_ids:
-            invalidate_multiple_tabs_cache(affected_tab_ids, invalidate_tabs=True)
+            invalidate_multiple_tabs_cache(affected_tab_ids,
+                                           invalidate_tabs=True)
             logger.info(
                 "Granular bulk cache invalidation completed for affected tabs: %s",
                 affected_tab_ids,
             )
         # Announce the update to listening clients
         event_data = {
-            "feeds_processed": processed_count,
-            "new_items": new_items_count,
-            "affected_tab_ids": (
-                sorted(list(affected_tab_ids)) if affected_tab_ids else []
-            ),
+            "feeds_processed":
+            processed_count,
+            "new_items":
+            new_items_count,
+            "affected_tab_ids":
+            (sorted(list(affected_tab_ids)) if affected_tab_ids else []),
         }
         msg = f"data: {json.dumps(event_data)}\n\n"
         announcer.announce(msg=msg)
         return (
-            jsonify(
-                {
-                    "message": "All feeds updated successfully.",
-                    "feeds_processed": processed_count,
-                    "new_items": new_items_count,
-                }
-            ),
+            jsonify({
+                "message": "All feeds updated successfully.",
+                "feeds_processed": processed_count,
+                "new_items": new_items_count,
+            }),
             200,
         )
     except Exception as e:
         logger.error("Error during /api/feeds/update-all: %s",
-                     e, exc_info=True)
+                     e,
+                     exc_info=True)
         # Consistent error response with other parts of the API
         return (
-            jsonify(
-                {"error": "An internal error occurred while updating all feeds."}),
+            jsonify({
+                "error":
+                "An internal error occurred while updating all feeds."
+            }),
             500,
         )
 
@@ -370,11 +377,10 @@ def update_feed(feed_id):
             exc_info=True,
         )
         return (
-            jsonify(
-                {
-                    "error": f"An internal error occurred while manually updating feed {feed_id}."
-                }
-            ),
+            jsonify({
+                "error":
+                f"An internal error occurred while manually updating feed {feed_id}."
+            }),
             500,
         )
 
@@ -391,8 +397,10 @@ def get_feed_items(feed_id):
         limit = int(request.args.get("limit", DEFAULT_PAGINATION_LIMIT))
     except (ValueError, TypeError):
         return (
-            jsonify(
-                {"error": "Offset and limit parameters must be valid integers."}),
+            jsonify({
+                "error":
+                "Offset and limit parameters must be valid integers."
+            }),
             400,
         )
 
@@ -404,15 +412,9 @@ def get_feed_items(feed_id):
     limit = min(limit, MAX_PAGINATION_LIMIT)
 
     # Query the database for the items, ordered by date
-    items = (
-        FeedItem.query.filter_by(feed_id=feed_id)
-        .order_by(
-            FeedItem.published_time.desc().nullslast(), FeedItem.fetched_time.desc()
-        )
-        .offset(offset)
-        .limit(limit)
-        .all()
-    )
+    items = (FeedItem.query.filter_by(feed_id=feed_id).order_by(
+        FeedItem.published_time.desc().nullslast(),
+        FeedItem.fetched_time.desc()).offset(offset).limit(limit).all())
 
     # Return the items as a JSON response
     return jsonify([item.to_dict() for item in items])
@@ -447,13 +449,15 @@ def mark_item_read(item_id):
         return jsonify({"message": f"Item {item_id} marked as read"}), 200
     except Exception as e:
         db.session.rollback()
-        logger.error(
-            "Error marking item %s as read: %s", item_id, str(e), exc_info=True
-        )
+        logger.error("Error marking item %s as read: %s",
+                     item_id,
+                     str(e),
+                     exc_info=True)
         # Let 500 handler manage response (or return specific error)
         return (
-            jsonify(
-                {"error": "An internal error occurred while marking the item as read."}
-            ),
+            jsonify({
+                "error":
+                "An internal error occurred while marking the item as read."
+            }),
             500,
         )

--- a/backend/blueprints/feeds.py
+++ b/backend/blueprints/feeds.py
@@ -4,7 +4,7 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
-from ..cache_utils import invalidate_tab_feeds_cache, invalidate_tabs_cache
+from ..cache_utils import invalidate_tab_feeds_cache, invalidate_tabs_cache, invalidate_multiple_tabs_cache
 from ..constants import (
     DEFAULT_FEED_ITEMS_LIMIT,
     DEFAULT_PAGINATION_LIMIT,
@@ -311,11 +311,9 @@ def api_update_all_feeds():
             new_items_count,
         )
         if new_items_count > 0 and affected_tab_ids:
-            for tab_id in affected_tab_ids:
-                invalidate_tab_feeds_cache(tab_id, invalidate_tabs=False)
-            invalidate_tabs_cache()
+            invalidate_multiple_tabs_cache(affected_tab_ids, invalidate_tabs=True)
             logger.info(
-                "Granular cache invalidation completed for affected tabs: %s",
+                "Granular bulk cache invalidation completed for affected tabs: %s",
                 affected_tab_ids,
             )
         # Announce the update to listening clients

--- a/backend/cache_utils.py
+++ b/backend/cache_utils.py
@@ -86,3 +86,30 @@ def invalidate_tab_feeds_cache(tab_id, invalidate_tabs=True):
     if invalidate_tabs:
         # Also invalidate the main tabs list because unread counts will have changed.
         invalidate_tabs_cache()
+
+
+def invalidate_multiple_tabs_cache(tab_ids, invalidate_tabs=True):
+    """Invalidates multiple tabs' feed caches efficiently using get_many/set_many.
+
+    Args:
+        tab_ids (iterable): The IDs of the tabs to invalidate the cache for.
+        invalidate_tabs (bool): If True, also invalidates the main tabs list cache.
+    """
+    if not tab_ids:
+        return
+
+    keys = [get_tab_version_key(tab_id) for tab_id in tab_ids]
+    # get_many returns a list of values in the same order as the keys
+    versions = cache.get_many(*keys)
+
+    # Handle None values and increment
+    updates = {}
+    for i, key in enumerate(keys):
+        current_version = versions[i] if versions[i] is not None else 1
+        updates[key] = current_version + 1
+
+    cache.set_many(updates)
+    logger.info("Invalidated cache for multiple tabs: %s", tab_ids)
+
+    if invalidate_tabs:
+        invalidate_tabs_cache()

--- a/backend/cache_utils.py
+++ b/backend/cache_utils.py
@@ -57,8 +57,7 @@ def make_tab_feeds_cache_key(tab_id):
     # Only include parameters that are used by the endpoint in the cache key.
     used_params = ["limit"]
     sorted_query = sorted(
-        (k, v) for k, v in request.args.items(multi=True) if k in used_params
-    )
+        (k, v) for k, v in request.args.items(multi=True) if k in used_params)
     query_string = urllib.parse.urlencode(sorted_query)
     base_key = f"view/tab/{tab_id}/v{tab_version}/tabs_v{tabs_version}/"
     return f"{base_key}?{query_string}" if query_string else base_key
@@ -81,8 +80,8 @@ def invalidate_tab_feeds_cache(tab_id, invalidate_tabs=True):
     version_key = get_tab_version_key(tab_id)
     new_version = get_version(version_key) + 1
     cache.set(version_key, new_version)
-    logger.info("Invalidated cache for tab %s. New version: %s",
-                tab_id, new_version)
+    logger.info("Invalidated cache for tab %s. New version: %s", tab_id,
+                new_version)
     if invalidate_tabs:
         # Also invalidate the main tabs list because unread counts will have changed.
         invalidate_tabs_cache()

--- a/tests/unit/test_cache_utils.py
+++ b/tests/unit/test_cache_utils.py
@@ -6,6 +6,7 @@ from backend.cache_utils import (
     get_tab_version_key,
     get_version,
     invalidate_tab_feeds_cache,
+    invalidate_multiple_tabs_cache,
     invalidate_tabs_cache,
     make_tab_feeds_cache_key,
     make_tabs_cache_key,
@@ -139,3 +140,37 @@ def test_invalidate_tab_feeds_cache():
     assert get_version(get_tab_version_key(2)) == 2
     assert get_version(get_tab_version_key(1)) == 3
     assert get_version(TABS_VERSION_KEY) == 3
+
+
+def test_invalidate_multiple_tabs_cache():
+    """Test invalidate_multiple_tabs_cache increments versions correctly for multiple tabs."""
+    # Ensure starting versions are 1
+    assert get_version(get_tab_version_key(1)) == 1
+    assert get_version(get_tab_version_key(2)) == 1
+    assert get_version(get_tab_version_key(3)) == 1
+    assert get_version(TABS_VERSION_KEY) == 1
+
+    # Invalidate tabs 1 and 2, but not 3, and do not invalidate tabs list
+    invalidate_multiple_tabs_cache([1, 2], invalidate_tabs=False)
+
+    assert get_version(get_tab_version_key(1)) == 2
+    assert get_version(get_tab_version_key(2)) == 2
+    assert get_version(get_tab_version_key(3)) == 1
+    assert get_version(TABS_VERSION_KEY) == 1
+
+    # Set some explicit versions
+    cache.set(get_tab_version_key(2), 5)
+    cache.set(get_tab_version_key(3), 10)
+
+    # Invalidate tabs 2 and 3, and invalidate tabs list
+    invalidate_multiple_tabs_cache([2, 3], invalidate_tabs=True)
+
+    assert get_version(get_tab_version_key(1)) == 2
+    assert get_version(get_tab_version_key(2)) == 6
+    assert get_version(get_tab_version_key(3)) == 11
+    assert get_version(TABS_VERSION_KEY) == 2
+
+    # Test empty list does nothing
+    invalidate_multiple_tabs_cache([], invalidate_tabs=True)
+    assert get_version(get_tab_version_key(1)) == 2
+    assert get_version(TABS_VERSION_KEY) == 2

--- a/tests/unit/test_cache_utils.py
+++ b/tests/unit/test_cache_utils.py
@@ -5,8 +5,8 @@ from backend.cache_utils import (
     TABS_VERSION_KEY,
     get_tab_version_key,
     get_version,
-    invalidate_tab_feeds_cache,
     invalidate_multiple_tabs_cache,
+    invalidate_tab_feeds_cache,
     invalidate_tabs_cache,
     make_tab_feeds_cache_key,
     make_tabs_cache_key,
@@ -70,7 +70,10 @@ def test_make_tabs_cache_key():
         pytest.param(
             "/api/tabs/1/feeds",
             1,
-            {TABS_VERSION_KEY: 3, get_tab_version_key(1): 4},
+            {
+                TABS_VERSION_KEY: 3,
+                get_tab_version_key(1): 4
+            },
             "view/tab/1/v4/tabs_v3/",
             [],
             id="custom_versions_no_query_params",
@@ -78,7 +81,10 @@ def test_make_tabs_cache_key():
         pytest.param(
             "/api/tabs/1/feeds?limit=10&other=ignored",
             1,
-            {TABS_VERSION_KEY: 3, get_tab_version_key(1): 4},
+            {
+                TABS_VERSION_KEY: 3,
+                get_tab_version_key(1): 4
+            },
             "view/tab/1/v4/tabs_v3/?limit=10",
             ["other=ignored"],
             id="with_query_params",
@@ -89,16 +95,18 @@ def test_make_tabs_cache_key():
         pytest.param(
             "/api/tabs/1/feeds?limit=10&limit=20",
             1,
-            {TABS_VERSION_KEY: 3, get_tab_version_key(1): 4},
+            {
+                TABS_VERSION_KEY: 3,
+                get_tab_version_key(1): 4
+            },
             "view/tab/1/v4/tabs_v3/?limit=10&limit=20",
             [],
             id="multiple_values_for_query_param",
         ),
     ],
 )
-def test_make_tab_feeds_cache_key(
-    url, tab_id, cache_versions, expected_key, unexpected_parts
-):
+def test_make_tab_feeds_cache_key(url, tab_id, cache_versions, expected_key,
+                                  unexpected_parts):
     """Test make_tab_feeds_cache_key incorporates versions and query params."""
     for k, v in cache_versions.items():
         cache.set(k, v)


### PR DESCRIPTION
💡 **What:** Added `invalidate_multiple_tabs_cache` using `get_many`/`set_many` to perform bulk cache invalidations and updated `api_update_all_feeds` to use it instead of looping over individual invalidations.

🎯 **Why:** Previously, `api_update_all_feeds` issued N sequential round-trips to the cache backend (Redis) to invalidate each affected tab. By batching these updates, we eliminate N-1 round trips, preventing cache connection bottlenecks during large updates.

📊 **Impact:** Reduces cache backend round-trips for system-wide updates from O(N) to O(1) where N is the number of affected tabs.

🔬 **Measurement:** Verify by running the test suite (`PYTHONPATH=. pytest tests/unit/test_cache_utils.py`) which asserts the correct behavior of the new `invalidate_multiple_tabs_cache` function.

---
*PR created automatically by Jules for task [17127065325863954874](https://jules.google.com/task/17127065325863954874) started by @sheepdestroyer*

## Summary by Sourcery

Optimize bulk cache invalidation for updated feeds by introducing a multi-tab cache invalidation helper and wiring it into the feeds update endpoint.

New Features:
- Add invalidate_multiple_tabs_cache helper to invalidate feed caches for multiple tabs in one operation.

Enhancements:
- Update api_update_all_feeds to use bulk cache invalidation for affected tabs instead of per-tab invalidations.
- Log bulk granular cache invalidation events with updated messaging.
- Document the new bulk cache invalidation approach and its rationale in the Bolt engineering notes.

Tests:
- Add unit test covering invalidate_multiple_tabs_cache behavior, including mixed existing versions and empty input handling.