### PR TITLE
⚡ Bolt: Optimize rendering with DocumentFragment

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2026-02-14 - Optimized Tab.to_dict serialization
 **Learning:** `Tab.to_dict()` triggered a separate SQL query for unread counts, causing N+1 issues when serializing lists of tabs (e.g. in `get_tabs`).
 **Action:** Implemented the same pattern as `Feed.to_dict()`: accept an optional `unread_count` parameter. Updated `get_tabs` to pre-calculate counts in a single query and pass them to `to_dict`.
+
+## 2026-03-01 - Minimized Layout Thrashing with DocumentFragment
+**Learning:** Calling `appendChild` inside a loop directly on an active DOM element (like `feedGrid`) triggers a reflow/repaint for every single item, causing layout thrashing and degrading UI performance, especially with many feeds.
+**Action:** Always batch DOM insertions using `document.createDocumentFragment()`. Append items to the fragment in the loop, then append the fragment to the active DOM element once. This ensures only a single reflow occurs.

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -158,6 +158,7 @@ async function loadFeedsForTab(tabId) {
         placeholders.forEach(p => p.remove());
 
         if (feeds && feeds.length > 0) {
+            const fragment = document.createDocumentFragment();
             feeds.forEach(feed => {
                 const widget = createFeedWidget(feed, {
                     onEdit: (id, url, name) => showEditFeedModal(id, url, name),
@@ -165,8 +166,9 @@ async function loadFeedsForTab(tabId) {
                     onMarkItemRead: handleMarkItemRead,
                     onLoadMore: handleLoadMoreItems
                 });
-                feedGrid.appendChild(widget);
+                fragment.appendChild(widget);
             });
+            feedGrid.appendChild(fragment);
         } else {
             // Create an empty-state message container for this tab
             const msg = document.createElement('div');


### PR DESCRIPTION
💡 What: Modified `loadFeedsForTab` in `frontend/js/app.js` to batch all feed widgets into a single `DocumentFragment` before appending them to the DOM.
🎯 Why: Previously, appending feed widgets to `feedGrid` inside a `.forEach` loop caused repeated DOM reflows and repaints, leading to layout thrashing.
📊 Impact: Significantly improves rendering performance when switching to tabs with many feeds, as it triggers only one layout reflow instead of N.
🔬 Measurement: Verify this by loading a tab with multiple feeds; layout timeline in devtools will show a single style recalculation for the feed elements.

---
*PR created automatically by Jules for task [16244764928266617882](https://jules.google.com/task/16244764928266617882) started by @sheepdestroyer*

## Summary by Sourcery

Batch feed widget rendering into a single DOM update to reduce layout thrashing when loading tab feeds.

Enhancements:
- Use a DocumentFragment to accumulate feed widgets before appending them to the feed grid, minimizing reflows and improving tab switching performance.

Documentation:
- Add a Bolt note documenting the performance issue with repeated appendChild calls and the DocumentFragment-based solution.