### PR TITLE
⚡ Bolt: Optimize OPML import feed URL query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2026-02-14 - Optimized Tab.to_dict serialization
 **Learning:** `Tab.to_dict()` triggered a separate SQL query for unread counts, causing N+1 issues when serializing lists of tabs (e.g. in `get_tabs`).
 **Action:** Implemented the same pattern as `Feed.to_dict()`: accept an optional `unread_count` parameter. Updated `get_tabs` to pre-calculate counts in a single query and pass them to `to_dict`.
+
+## 2026-02-15 - Single-column retrieval optimization
+**Learning:** `Feed.query.all()` instantiates full ORM objects for every row, which requires significant memory and CPU.
+**Action:** When you only need one or two specific columns (e.g. `url`), use `db.session.query(Feed.url).all()` to fetch tuples. This skips full object instantiation and is significantly faster and less memory-intensive. Unpack with `{url for url, in query}`.

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -620,7 +620,10 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # OPTIMIZATION: Querying only the 'url' column avoids full ORM object instantiation,
     # significantly saving memory and CPU compared to Feed.query.all().
-    all_existing_feed_urls_set = {url for url, in db.session.query(Feed.url).all()}
+    all_existing_feed_urls_set = {
+        url
+        for (url, ) in db.session.query(Feed.url).all()
+    }
 
     # Announce start
     announcer.announce(

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -618,7 +618,9 @@ def import_opml(opml_file_stream, requested_tab_id_str):
         )
         return result, None
 
-    all_existing_feed_urls_set = {feed.url for feed in Feed.query.all()}
+    # OPTIMIZATION: Querying only the 'url' column avoids full ORM object instantiation,
+    # significantly saving memory and CPU compared to Feed.query.all().
+    all_existing_feed_urls_set = {url for url, in db.session.query(Feed.url).all()}
 
     # Announce start
     announcer.announce(


### PR DESCRIPTION
💡 **What**: Changed `Feed.query.all()` to `db.session.query(Feed.url).all()` when creating the set of all existing feed URLs during OPML imports.

🎯 **Why**: The original code queried the entire `Feed` model and instantiated full ORM objects for every row in the database just to check if an imported URL already exists. For users with a large number of feeds, this caused unnecessary memory allocations and CPU overhead in SQLAlchemy's object creation and tracking.

📊 **Impact**: Reduces CPU and memory overhead during OPML import significantly. The new query returns simple tuples instead of full objects, changing operation cost from `O(N)` heavy object instantiations to `O(N)` lightweight tuple creations.

🔬 **Measurement**: Verified tests (`pnpm test` equivalent, `python -m pytest`) still pass, and the optimization maintains logical correctness because the result is still a comprehensive set of URL strings.

---
*PR created automatically by Jules for task [15046409861170716853](https://jules.google.com/task/15046409861170716853) started by @sheepdestroyer*

## Summary by Sourcery

Optimize OPML import to reduce memory and CPU overhead when building the set of existing feed URLs.

Enhancements:
- Limit OPML import feed URL lookup to querying only the URL column instead of instantiating full Feed ORM objects.
- Document the single-column retrieval optimization pattern in the Bolt engineering notes for future similar queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database query performance for feed URL retrieval to reduce memory usage and improve application efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->