### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak file type validation in OPML import

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** `feedparser` library relies on standard XML libraries which may be vulnerable to XXE (XML External Entity) attacks if not configured securely or if the environment defaults are insecure.
 **Learning:** Even if the current environment's Python version (e.g. 3.12) defaults to safe XML parsing, relying on implicit defaults is risky. Explicit validation using `defusedxml` is required for robust security.
 **Prevention:** Implemented a pre-validation step using `defusedxml.sax.parseString` to check for DTDs and entities before passing content to `feedparser`. This ensures XXE attacks are blocked regardless of the underlying parser's configuration.
+
+## 2026-02-09 - Weak File Type Validation in OPML Import
+**Vulnerability:** OPML import feature historically allowed `.txt` extensions in addition to standard XML/OPML extensions (`.xml`, `.opml`).
+**Learning:** Accepting overly broad file extensions for structured data imports increases the attack surface for file-handling vulnerabilities or unexpected content processing by backend parsers. The validation logic must strictly align with the expected data types.
+**Prevention:** Enforced strict allowlist validation strictly for `.opml` and `.xml` file extensions in the OPML import route and introduced a regression test (`test_import_opml_txt_file_rejected`) to actively prevent weak type acceptance.

--- a/backend/blueprints/opml.py
+++ b/backend/blueprints/opml.py
@@ -88,7 +88,7 @@ def _validate_opml_file_request():
         return None, (jsonify({"error": "File object is empty"}), 400)
 
     # Basic security: check file extension
-    allowed_extensions = (".opml", ".xml", ".txt")
+    allowed_extensions = (".opml", ".xml")
     _, ext = os.path.splitext(opml_file.filename)
     if ext.lower() not in allowed_extensions:
         err_msg = f"Invalid file type. Allowed: {', '.join(allowed_extensions)}"

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1700,6 +1700,17 @@ def test_import_opml_no_file(client):
     assert "No file part" in response.json["error"]
 
 
+def test_import_opml_txt_file_rejected(client):
+    """Test POST /api/opml/import with a .txt file is rejected."""
+    opml_content = "This is a text file, not xml"
+    opml_file = (io.BytesIO(opml_content.encode("utf-8")), "test.txt")
+    response = client.post("/api/opml/import",
+                           data={"file": opml_file},
+                           content_type="multipart/form-data")
+    assert response.status_code == 400
+    assert "Invalid file type. Allowed: .opml, .xml" in response.json["error"]
+
+
 def test_import_opml_empty_filename(client):
     """Test POST /api/opml/import with an empty filename (simulates no file selected)."""
     opml_file = (io.BytesIO(b"content"), "")  # Empty filename


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The OPML import route historically accepted `.txt` file extensions alongside the required XML-based extensions (`.opml`, `.xml`).
🎯 Impact: Accepting overly broad text files increases the attack surface for file-handling logic and unexpected content processing. While `defusedxml` protects against XXE, processing unstructured text files as XML can cause unpredictable behavior or server strain when parsed.
🔧 Fix: Updated the `allowed_extensions` tuple in `_validate_opml_file_request` (inside `backend/blueprints/opml.py`) to explicitly deny `.txt` files, thereby strictly enforcing the file type.
✅ Verification: Added `test_import_opml_txt_file_rejected` in `tests/unit/test_app.py` to assert that uploading a `.txt` file responds with a 400 Bad Request. All tests run cleanly.

---
*PR created automatically by Jules for task [13222810994976403824](https://jules.google.com/task/13222810994976403824) started by @sheepdestroyer*

## Summary by Sourcery

Tighten OPML import file-type validation to only accept XML-based formats and document the associated security learning.

Bug Fixes:
- Reject .txt files in the OPML import endpoint by restricting the allowed file extensions to .opml and .xml.

Documentation:
- Extend Sentinel security notes with a new entry describing the weak file-type validation in OPML import and its mitigation.

Tests:
- Add a regression test ensuring that uploading a .txt file to the OPML import endpoint returns a 400 Bad Request with an appropriate error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OPML import validation has been tightened to only accept `.opml` and `.xml` files. Files with other extensions, including previously allowed `.txt` files, will now be rejected with an error message specifying the acceptable file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->