### PR TITLE
⚡ Bolt: Optimize cache invalidations with get_many/set_many

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2026-02-14 - Optimized Tab.to_dict serialization
 **Learning:** `Tab.to_dict()` triggered a separate SQL query for unread counts, causing N+1 issues when serializing lists of tabs (e.g. in `get_tabs`).
 **Action:** Implemented the same pattern as `Feed.to_dict()`: accept an optional `unread_count` parameter. Updated `get_tabs` to pre-calculate counts in a single query and pass them to `to_dict`.
+
+## 2026-02-19 - Bulk cache invalidation with cache.get_many/set_many
+**Learning:** Iteratively querying and setting cache keys one-by-one inside a loop (e.g. `invalidate_tab_feeds_cache` inside a loop over `affected_tab_ids`) causes excessive overhead and round-trips to the cache backend (Redis/SimpleCache).
+**Action:** Use `cache.get_many(*keys)` to retrieve current versions in a single query, increment them, and `cache.set_many(mapping)` to update them in a single round-trip. This bulk operation reduces latency significantly, especially during processes that affect many entities simultaneously (like `api_update_all_feeds`). Ensure input iterables are cast to `list` to prevent generator exhaustion.

--- a/backend/app.py
+++ b/backend/app.py
@@ -35,14 +35,15 @@ app = Flask(__name__)
 # This ensures request.is_secure is accurate for HSTS.
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
 app.config["PROJECT_ROOT"] = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), ".."))
+    os.path.join(os.path.dirname(__file__), "..")
+)
 
 # Configure CORS with specific allowed origins
 allowed_origins_str = os.environ.get(
-    "CORS_ALLOWED_ORIGINS", "http://localhost:8080,http://127.0.0.1:8080")
+    "CORS_ALLOWED_ORIGINS", "http://localhost:8080,http://127.0.0.1:8080"
+)
 allowed_origins = [
-    origin.strip() for origin in allowed_origins_str.split(",")
-    if origin.strip()
+    origin.strip() for origin in allowed_origins_str.split(",") if origin.strip()
 ]
 CORS(app, origins=allowed_origins, resources={r"/api/*": {}})
 
@@ -54,8 +55,7 @@ if app.config.get("TESTING") or os.environ.get("TESTING") == "true":
     app.config["CACHE_TYPE"] = (
         "SimpleCache"  # Use SimpleCache for tests, no Redis needed
     )
-    logger.info(
-        "TESTING mode: Using in-memory SQLite database and SimpleCache.")
+    logger.info("TESTING mode: Using in-memory SQLite database and SimpleCache.")
 else:
     # Existing database configuration logic
     default_db_path_in_container = "/app/data/sheepvibes.db"
@@ -65,19 +65,20 @@ else:
         if db_path_env.startswith("sqlite:///"):
             app.config["SQLALCHEMY_DATABASE_URI"] = db_path_env
             logger.info(
-                "Using DATABASE_PATH environment variable directly: %s",
-                db_path_env)
+                "Using DATABASE_PATH environment variable directly: %s", db_path_env
+            )
         else:
             db_path = db_path_env
             app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_path}"
             logger.info(
-                "Using DATABASE_PATH environment variable for file path: %s",
-                db_path)
+                "Using DATABASE_PATH environment variable for file path: %s", db_path
+            )
     else:
         # Default path logic
         if not os.path.exists("/app"):  # Assume local development
             project_root = os.path.abspath(
-                os.path.join(os.path.dirname(__file__), ".."))
+                os.path.join(os.path.dirname(__file__), "..")
+            )
             local_data_dir = os.path.join(project_root, "data")
             os.makedirs(local_data_dir, exist_ok=True)
             db_path = os.path.join(local_data_dir, "sheepvibes.db")
@@ -95,8 +96,9 @@ else:
 
     # --- Cache Configuration for non-testing ---
     app.config["CACHE_TYPE"] = "RedisCache"
-    app.config["CACHE_REDIS_URL"] = os.environ.get("CACHE_REDIS_URL",
-                                                   "redis://localhost:6379/0")
+    app.config["CACHE_REDIS_URL"] = os.environ.get(
+        "CACHE_REDIS_URL", "redis://localhost:6379/0"
+    )
 
 # Disable modification tracking
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
@@ -115,15 +117,16 @@ app.register_blueprint(items_bp)
 # --- Scheduler Configuration ---
 
 UPDATE_INTERVAL_MINUTES = int(
-    os.environ.get("UPDATE_INTERVAL_MINUTES", UPDATE_INTERVAL_MINUTES_DEFAULT))
+    os.environ.get("UPDATE_INTERVAL_MINUTES", UPDATE_INTERVAL_MINUTES_DEFAULT)
+)
 OPML_AUTOSAVE_INTERVAL_MINUTES = int(
-    os.environ.get("OPML_AUTOSAVE_INTERVAL_MINUTES",
-                   OPML_AUTOSAVE_INTERVAL_MINUTES_DEFAULT))
+    os.environ.get(
+        "OPML_AUTOSAVE_INTERVAL_MINUTES", OPML_AUTOSAVE_INTERVAL_MINUTES_DEFAULT
+    )
+)
 
 
-@scheduler.scheduled_job("interval",
-                         minutes=UPDATE_INTERVAL_MINUTES,
-                         id="update_feeds")
+@scheduler.scheduled_job("interval", minutes=UPDATE_INTERVAL_MINUTES, id="update_feeds")
 def scheduled_feed_update():
     """Scheduled job to periodically update all feeds in the database."""
     # Use a file lock to ensure only one worker runs this job
@@ -137,8 +140,7 @@ def scheduled_feed_update():
                     UPDATE_INTERVAL_MINUTES,
                 )
                 try:
-                    feeds_updated, new_items, affected_tab_ids = update_all_feeds(
-                    )
+                    feeds_updated, new_items, affected_tab_ids = update_all_feeds()
                     logger.info(
                         "Scheduled update completed: %s feeds updated, %s new items",
                         feeds_updated,
@@ -146,8 +148,9 @@ def scheduled_feed_update():
                     )
                     # Invalidate the cache after updates
                     if new_items > 0 and affected_tab_ids:
-                        invalidate_multiple_tabs_cache(affected_tab_ids,
-                                                       invalidate_tabs=False)
+                        invalidate_multiple_tabs_cache(
+                            affected_tab_ids, invalidate_tabs=False
+                        )
                         invalidate_tabs_cache()
                         logger.info(
                             "Granular cache invalidation completed for affected tabs: %s",
@@ -156,27 +159,27 @@ def scheduled_feed_update():
 
                     # Announce the update to any listening clients
                     event_data = {
-                        "feeds_processed":
-                        feeds_updated,
-                        "new_items":
-                        new_items,
-                        "affected_tab_ids": (sorted(list(affected_tab_ids))
-                                             if affected_tab_ids else []),
+                        "feeds_processed": feeds_updated,
+                        "new_items": new_items,
+                        "affected_tab_ids": (
+                            sorted(list(affected_tab_ids)
+                                   ) if affected_tab_ids else []
+                        ),
                     }
                     msg = f"data: {json.dumps(event_data)}\n\n"
                     announcer.announce(msg=msg)
                 except Exception as e:
-                    logger.error("Error during scheduled feed update: %s",
-                                 e,
-                                 exc_info=True)
+                    logger.error(
+                        "Error during scheduled feed update: %s", e, exc_info=True
+                    )
     except Timeout:
         # Lock acquisition failed (another worker is running the job), just skip
         pass
 
 
-@scheduler.scheduled_job("interval",
-                         minutes=OPML_AUTOSAVE_INTERVAL_MINUTES,
-                         id="autosave_opml")
+@scheduler.scheduled_job(
+    "interval", minutes=OPML_AUTOSAVE_INTERVAL_MINUTES, id="autosave_opml"
+)
 def scheduled_opml_autosave():
     """Scheduled job to periodically save OPML to disk."""
     with app.app_context():
@@ -201,32 +204,37 @@ if not app.config.get("TESTING"):
 
 # --- Security Headers ---
 
-CSP_POLICY = ("default-src 'self'; "
-              "img-src * data:; "
-              "script-src 'self'; "
-              "style-src 'self' 'unsafe-inline'; "
-              "connect-src 'self'; "
-              "object-src 'none'; "
-              "base-uri 'self'; "
-              "form-action 'self'; "
-              "frame-ancestors 'self'")
+CSP_POLICY = (
+    "default-src 'self'; "
+    "img-src * data:; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "connect-src 'self'; "
+    "object-src 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'; "
+    "frame-ancestors 'self'"
+)
 
 PERMISSIONS_POLICY = ", ".join(
-    sorted([
-        "accelerometer=()",
-        "autoplay=()",
-        "camera=()",
-        "display-capture=()",
-        "fullscreen=()",
-        "geolocation=()",
-        "gyroscope=()",
-        "magnetometer=()",
-        "microphone=()",
-        "midi=()",
-        "payment=()",
-        "usb=()",
-        "xr-spatial-tracking=()",
-    ]))
+    sorted(
+        [
+            "accelerometer=()",
+            "autoplay=()",
+            "camera=()",
+            "display-capture=()",
+            "fullscreen=()",
+            "geolocation=()",
+            "gyroscope=()",
+            "magnetometer=()",
+            "microphone=()",
+            "midi=()",
+            "payment=()",
+            "usb=()",
+            "xr-spatial-tracking=()",
+        ]
+    )
+)
 
 
 @app.after_request
@@ -267,7 +275,8 @@ def add_security_headers(response):
     # Enforce HTTPS for all future connections to this domain.
     if request.is_secure:
         response.headers["Strict-Transport-Security"] = (
-            "max-age=31536000; includeSubDomains")
+            "max-age=31536000; includeSubDomains"
+        )
 
     return response
 
@@ -294,7 +303,8 @@ def internal_error(error):
 # --- Static and Stream Routes ---
 
 FRONTEND_FOLDER = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "frontend"))
+    os.path.join(os.path.dirname(__file__), "..", "frontend")
+)
 
 
 @app.route("/")

--- a/backend/app.py
+++ b/backend/app.py
@@ -12,7 +12,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from .blueprints.feeds import feeds_bp, items_bp
 from .blueprints.opml import autosave_opml, opml_bp
 from .blueprints.tabs import tabs_bp
-from .cache_utils import invalidate_tab_feeds_cache, invalidate_tabs_cache
+from .cache_utils import invalidate_multiple_tabs_cache, invalidate_tabs_cache
 from .constants import (
     OPML_AUTOSAVE_INTERVAL_MINUTES_DEFAULT,
     UPDATE_INTERVAL_MINUTES_DEFAULT,
@@ -146,8 +146,7 @@ def scheduled_feed_update():
                     )
                     # Invalidate the cache after updates
                     if new_items > 0 and affected_tab_ids:
-                        for tab_id in affected_tab_ids:
-                            invalidate_tab_feeds_cache(tab_id,
+                        invalidate_multiple_tabs_cache(affected_tab_ids,
                                                        invalidate_tabs=False)
                         invalidate_tabs_cache()
                         logger.info(

--- a/backend/blueprints/feeds.py
+++ b/backend/blueprints/feeds.py
@@ -5,9 +5,9 @@ import logging
 from flask import Blueprint, jsonify, request
 
 from ..cache_utils import (
-    invalidate_tab_feeds_cache,
     invalidate_multiple_tabs_cache,
-    invalidate_tabs_cache
+    invalidate_tab_feeds_cache,
+    invalidate_tabs_cache,
 )
 from ..constants import (
     DEFAULT_FEED_ITEMS_LIMIT,
@@ -315,7 +315,8 @@ def api_update_all_feeds():
             new_items_count,
         )
         if new_items_count > 0 and affected_tab_ids:
-            invalidate_multiple_tabs_cache(affected_tab_ids, invalidate_tabs=False)
+            invalidate_multiple_tabs_cache(
+                affected_tab_ids, invalidate_tabs=False)
             invalidate_tabs_cache()
             logger.info(
                 "Granular cache invalidation completed for affected tabs: %s",

--- a/backend/blueprints/feeds.py
+++ b/backend/blueprints/feeds.py
@@ -4,7 +4,11 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
-from ..cache_utils import invalidate_tab_feeds_cache, invalidate_tabs_cache
+from ..cache_utils import (
+    invalidate_tab_feeds_cache,
+    invalidate_multiple_tabs_cache,
+    invalidate_tabs_cache
+)
 from ..constants import (
     DEFAULT_FEED_ITEMS_LIMIT,
     DEFAULT_PAGINATION_LIMIT,
@@ -311,8 +315,7 @@ def api_update_all_feeds():
             new_items_count,
         )
         if new_items_count > 0 and affected_tab_ids:
-            for tab_id in affected_tab_ids:
-                invalidate_tab_feeds_cache(tab_id, invalidate_tabs=False)
+            invalidate_multiple_tabs_cache(affected_tab_ids, invalidate_tabs=False)
             invalidate_tabs_cache()
             logger.info(
                 "Granular cache invalidation completed for affected tabs: %s",

--- a/backend/cache_utils.py
+++ b/backend/cache_utils.py
@@ -105,7 +105,8 @@ def invalidate_multiple_tabs_cache(tab_ids, invalidate_tabs=True):
 
     new_versions_dict = {}
     for key, current_val in zip(version_keys, current_versions):
-        new_versions_dict[key] = (current_val if current_val is not None else 1) + 1
+        new_versions_dict[key] = (
+            current_val if current_val is not None else 1) + 1
 
     cache.set_many(new_versions_dict)
     logger.info("Invalidated cache for tabs %s.", tab_ids_list)

--- a/backend/cache_utils.py
+++ b/backend/cache_utils.py
@@ -86,3 +86,29 @@ def invalidate_tab_feeds_cache(tab_id, invalidate_tabs=True):
     if invalidate_tabs:
         # Also invalidate the main tabs list because unread counts will have changed.
         invalidate_tabs_cache()
+
+
+def invalidate_multiple_tabs_cache(tab_ids, invalidate_tabs=True):
+    """Invalidates feed caches for multiple tabs efficiently using bulk operations.
+
+    Args:
+        tab_ids (iterable): An iterable of tab IDs to invalidate.
+        invalidate_tabs (bool): If True, also invalidates the main tabs list cache.
+    """
+    # Prevent generator exhaustion by casting to a list
+    tab_ids_list = list(tab_ids)
+    if not tab_ids_list:
+        return
+
+    version_keys = [get_tab_version_key(tid) for tid in tab_ids_list]
+    current_versions = cache.get_many(*version_keys)
+
+    new_versions_dict = {}
+    for key, current_val in zip(version_keys, current_versions):
+        new_versions_dict[key] = (current_val if current_val is not None else 1) + 1
+
+    cache.set_many(new_versions_dict)
+    logger.info("Invalidated cache for tabs %s.", tab_ids_list)
+
+    if invalidate_tabs:
+        invalidate_tabs_cache()

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -34,7 +34,7 @@ from defusedxml.common import (
 from sqlalchemy.exc import IntegrityError
 
 from .cache_utils import (
-    invalidate_tab_feeds_cache,
+    invalidate_multiple_tabs_cache,
     invalidate_tabs_cache,
 )
 from .constants import (
@@ -578,8 +578,7 @@ def _invalidate_import_caches(affected_tab_ids_set):
     """Invalidates caches for all tabs affected by the import."""
     if not affected_tab_ids_set:
         return
-    for tab_id in affected_tab_ids_set:
-        invalidate_tab_feeds_cache(tab_id, invalidate_tabs=False)
+    invalidate_multiple_tabs_cache(affected_tab_ids_set, invalidate_tabs=False)
     invalidate_tabs_cache()
     logger.info(
         "OPML import: Invalidated caches for tabs: %s.",

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -115,8 +115,9 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(processed_count, total_count,
-                                     last_announced_percent):
+def _calculate_and_announce_progress(
+    processed_count, total_count, last_announced_percent
+):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -128,10 +129,12 @@ def _calculate_and_announce_progress(processed_count, total_count,
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (processed_count == 0 or processed_count >= total_count
-                       or (current_percent != last_announced_percent
-                           and current_percent % 5 == 0)
-                       or processed_count % 20 == 0)
+    should_announce = (
+        processed_count == 0
+        or processed_count >= total_count
+        or (current_percent != last_announced_percent and current_percent % 5 == 0)
+        or processed_count % 20 == 0
+    )
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -239,8 +242,9 @@ def _process_folder_node(
         try:
             nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
                 element_name)
-            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
-                                nested_tab_name))
+            state.stack.append(
+                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
+            )
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -250,7 +254,8 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
+        )
         return
 
     state.skipped_count += 1
@@ -291,11 +296,13 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [(
-        list(reversed(initial_outline_elements)),
-        top_level_tab_id,
-        top_level_tab_name,
-    )]
+    stack = [
+        (
+            list(reversed(initial_outline_elements)),
+            top_level_tab_id,
+            top_level_tab_name,
+        )
+    ]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -313,8 +320,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines,
-                last_announced_percent)
+                processed_outline_count, total_outlines, last_announced_percent
+            )
 
             _process_single_outline_node(
                 outline_element,
@@ -368,13 +375,15 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation).first()
+                name=default_tab_name_for_creation
+            ).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0)
+                    name=default_tab_name_for_creation, order=0
+                )
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -399,7 +408,8 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation).first()
+                        name=default_tab_name_for_creation
+                    ).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -415,10 +425,7 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {
-                                    "error":
-                                    "Failed to create a default tab for import."
-                                },
+                                {"error": "Failed to create a default tab for import."},
                                 500,
                             ),
                         )
@@ -433,10 +440,7 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {
-                                "error":
-                                "Failed to create a default tab for import."
-                            },
+                            {"error": "Failed to create a default tab for import."},
                             500,
                         ),
                     )
@@ -449,16 +453,13 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({
-                "error": "Failed to determine a target tab for import."
-            }, 500),
+            ({"error": "Failed to determine a target tab for import."}, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
-                               affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -489,13 +490,10 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except (SafeET.ParseError, DefusedXmlException) as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s",
-                     e,
-                     exc_info=True)
+        logger.error(
+            "OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
         return None, (
-            {
-                "error": "Malformed OPML file. Please check the file format."
-            },
+            {"error": "Malformed OPML file. Please check the file format."},
             400,
         )
     except OSError as e:
@@ -505,10 +503,7 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {
-                "error":
-                "Could not parse OPML file. Please check the file format."
-            },
+            {"error": "Could not parse OPML file. Please check the file format."},
             400,
         )
 
@@ -531,13 +526,14 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
+                )
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
-                                                                    1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - \
+                1 or (i + 1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -567,9 +563,7 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {
-                "error": "Database error during final feed import step."
-            },
+            {"error": "Database error during final feed import step."},
             500,
         )
 
@@ -634,7 +628,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list)
+        state.newly_added_feeds_list
+    )
     if not success:
         return None, error_resp
 
@@ -668,19 +663,13 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message":
-        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count":
-        imported_final_count,
-        "skipped_count":
-        skipped_final_count,
-        "tab_id":
-        top_level_target_tab_id,
-        "tab_name":
-        top_level_target_tab_name,
-        "affected_tab_ids":
-        list(state.affected_tab_ids_set),
+        "imported_count": imported_final_count,
+        "skipped_count": skipped_final_count,
+        "tab_id": top_level_target_tab_id,
+        "tab_name": top_level_target_tab_name,
+        "affected_tab_ids": list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -803,8 +792,7 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
-                parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -864,8 +852,14 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (ip.is_private or ip.is_loopback or ip.is_link_local
-                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -896,8 +890,9 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
         if self._tunnel_host:
             self._tunnel()
@@ -933,8 +928,9 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -998,15 +994,16 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning("Blocked unsafe redirect to: %s",
-                           _sanitize_for_log(absolute_newurl))
-            raise urllib.error.HTTPError(absolute_newurl, code,
-                                         "Blocked unsafe redirect", headers,
-                                         fp)
+            logger.warning(
+                "Blocked unsafe redirect to: %s", _sanitize_for_log(
+                    absolute_newurl)
+            )
+            raise urllib.error.HTTPError(
+                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
+            )
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers,
-                                           absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1035,8 +1032,9 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception("Error in fetch thread for feed %s",
-                         _sanitize_for_log(feed_url))
+        logger.exception(
+            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
+        )
         return None
 
 
@@ -1115,8 +1113,9 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(http_handler, https_handler,
-                                             redirect_handler)
+        opener = urllib.request.build_opener(
+            http_handler, https_handler, redirect_handler
+        )
 
         req = urllib.request.Request(
             feed_url,
@@ -1171,8 +1170,8 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s",
-                           safe_log_url)
+            logger.warning(
+                "Feed rejected due to security violation: %s", safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1237,9 +1236,12 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (db.session.query(
-        FeedItem.id, FeedItem.guid, FeedItem.link,
-        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
+    items_tuple = (
+        db.session.query(FeedItem.id, FeedItem.guid,
+                         FeedItem.link, FeedItem.title)
+        .filter_by(feed_id=feed_db_obj.id)
+        .all()
+    )
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1266,8 +1268,10 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning("Failed to sort entries for feed %s",
-                       _sanitize_for_log(feed_db_obj.name))
+        logger.warning(
+            "Failed to sort entries for feed %s", _sanitize_for_log(
+                feed_db_obj.name)
+        )
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1316,9 +1320,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-                db_guid,
-                batch_processed_guids,
-                feed_db_obj.name,
+            db_guid,
+            batch_processed_guids,
+            feed_db_obj.name,
         ):
             continue
 
@@ -1332,13 +1336,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            ))
+            )
+        )
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
-                          entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1364,9 +1368,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(
-            FeedItem.id == existing_item_data.id).update(
-                updates, synchronize_session=False)
+        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
+            updates, synchronize_session=False
+        )
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1443,8 +1447,10 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug("Individually added item: %s",
-                         _sanitize_for_log(item.title[:50]))
+            logger.debug(
+                "Individually added item: %s", _sanitize_for_log(
+                    item.title[:50])
+            )
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1496,11 +1502,17 @@ def _enforce_feed_limit(feed_db_obj: Feed):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    stmt = (db.select(FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
-        FeedItem.published_time.desc().nullslast(),
-        FeedItem.fetched_time.desc().nullslast(),
-        FeedItem.id.desc(),
-    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN))
+    stmt = (
+        db.select(FeedItem.id)
+        .filter_by(feed_id=feed_db_obj.id)
+        .order_by(
+            FeedItem.published_time.desc().nullslast(),
+            FeedItem.fetched_time.desc().nullslast(),
+            FeedItem.id.desc(),
+        )
+        .offset(MAX_ITEMS_PER_FEED)
+        .limit(EVICTION_LIMIT_PER_RUN)
+    )
 
     ids_to_evict = list(db.session.scalars(stmt))
 
@@ -1511,9 +1523,12 @@ def _enforce_feed_limit(feed_db_obj: Feed):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i:i + chunk_size]
-        deleted_count += (db.session.query(FeedItem).filter(
-            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
+        chunk = ids_to_evict[i: i + chunk_size]
+        deleted_count += (
+            db.session.query(FeedItem)
+            .filter(FeedItem.id.in_(chunk))
+            .delete(synchronize_session=False)
+        )
 
     if deleted_count > 0:
         logger.info(
@@ -1621,19 +1636,17 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).",
-                total_feeds)
+    logger.info(
+        "Starting update process for %d feeds (Parallelized).", total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
     actual_workers = min(MAX_CONCURRENT_FETCHES,
                          total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(
-            max_workers=actual_workers) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed
-            for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1647,7 +1660,8 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed)
+                    feed_obj, parsed_feed
+                )
                 if success:
                     successful_count += 1
                     total_new_items += new_items


### PR DESCRIPTION
💡 What: Replaced iterative sequential cache key invalidations with a bulk approach using `cache.get_many()` and `cache.set_many()` in a new `invalidate_multiple_tabs_cache` function.
🎯 Why: Iteratively querying and setting cache keys inside a loop (like iterating over affected tabs after an import or bulk update) causes excessive latency and round-trips to the cache backend (Redis/Memcached). This N+1 cache interaction bottleneck significantly degraded performance during bulk operations.
📊 Impact: Consolidates operations into a single round-trip, significantly reducing overhead and response times when modifying multiple tabs simultaneously.
🔬 Measurement: Verified that tests pass and the implementation gracefully handles default initialization, type casting to prevent generator exhaustion, and preserves behavior entirely.

---
*PR created automatically by Jules for task [12724997931743354482](https://jules.google.com/task/12724997931743354482) started by @sheepdestroyer*

## Summary by Sourcery

Introduce bulk tab cache invalidation and apply it to bulk update paths to reduce cache round-trips and improve performance.

Enhancements:
- Add a helper to invalidate caches for multiple tabs in a single bulk cache operation.
- Refactor scheduled feed updates, bulk feed updates, and import cache invalidation to use the new bulk tab cache invalidation helper.
- Document the bulk cache invalidation optimization and its rationale in the Bolt notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized cache invalidation performance by replacing iterative per-item operations with bulk batch processing, reducing round-trip calls to the caching layer.

* **Chores**
  * Code cleanup and formatting adjustments throughout the backend infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->