### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix allowed extensions for OPML import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Thumbs.db
 # Agent/Tool temporary files
 tests/artifacts/
 # (None for this PR to keep it focused)
+agent-tools

--- a/backend/blueprints/opml.py
+++ b/backend/blueprints/opml.py
@@ -88,7 +88,7 @@ def _validate_opml_file_request():
         return None, (jsonify({"error": "File object is empty"}), 400)
 
     # Basic security: check file extension
-    allowed_extensions = (".opml", ".xml", ".txt")
+    allowed_extensions = (".opml", ".xml")
     _, ext = os.path.splitext(opml_file.filename)
     if ext.lower() not in allowed_extensions:
         err_msg = f"Invalid file type. Allowed: {', '.join(allowed_extensions)}"

--- a/backend/blueprints/opml.py
+++ b/backend/blueprints/opml.py
@@ -38,8 +38,8 @@ def _generate_opml_string(tabs=None):
 
     if tabs is None:
         # Eager load feeds to avoid N+1 queries
-        tabs = Tab.query.options(selectinload(Tab.feeds)).order_by(
-            Tab.order).all()
+        tabs = Tab.query.options(selectinload(
+            Tab.feeds)).order_by(Tab.order).all()
 
     for tab in tabs:
         # Skip tabs with no feeds
@@ -65,10 +65,9 @@ def _generate_opml_string(tabs=None):
 
     # Use unsafe_tostring because we are strictly generating XML, not parsing it.
     # We encode to utf-8 and decode to unicode to ensure a correct XML declaration.
-    opml_string = unsafe_tostring(opml_element,
-                                  encoding="utf-8",
-                                  method="xml",
-                                  xml_declaration=True).decode("utf-8")
+    opml_string = unsafe_tostring(
+        opml_element, encoding="utf-8", method="xml", xml_declaration=True
+    ).decode("utf-8")
 
     feed_count = sum(len(tab.feeds) for tab in tabs)
     tab_count = sum(1 for tab in tabs if tab.feeds)
@@ -82,8 +81,7 @@ def _validate_opml_file_request():
         return None, (jsonify({"error": "No file part in the request"}), 400)
     opml_file = request.files["file"]
     if opml_file.filename == "":
-        return None, (jsonify({"error":
-                               "No file selected for uploading"}), 400)
+        return None, (jsonify({"error": "No file selected for uploading"}), 400)
     if not opml_file:
         return None, (jsonify({"error": "File object is empty"}), 400)
 
@@ -114,8 +112,8 @@ def import_opml():
     requested_tab_id_str = request.form.get("tab_id")
 
     # Call the service function
-    result, error_info = import_opml_service(opml_file.stream,
-                                             requested_tab_id_str)
+    result, error_info = import_opml_service(
+        opml_file.stream, requested_tab_id_str)
 
     if error_info:
         error_json, status_code = error_info
@@ -143,7 +141,8 @@ def export_opml():
 
     response = Response(opml_string, mimetype="application/xml")
     response.headers["Content-Disposition"] = (
-        'attachment; filename="sheepvibes_feeds.opml"')
+        'attachment; filename="sheepvibes_feeds.opml"'
+    )
 
     logger.info(
         "Successfully generated OPML export for %d feeds across %d tabs.",
@@ -178,12 +177,12 @@ def _get_autosave_directory():
                 abs_db_path = os.path.abspath(db_path)
                 data_dir = os.path.dirname(abs_db_path)
                 logger.debug(
-                    "Resolved autosave directory from SQLite path: %s",
-                    data_dir)
+                    "Resolved autosave directory from SQLite path: %s", data_dir
+                )
             except Exception:
                 logger.warning(
-                    "Could not resolve absolute path for SQLite DB: %s",
-                    db_path)
+                    "Could not resolve absolute path for SQLite DB: %s", db_path
+                )
 
     if not data_dir:
         # 3. Fall back to PROJECT_ROOT/data
@@ -193,7 +192,8 @@ def _get_autosave_directory():
 
     if not data_dir:
         logger.warning(
-            "Could not determine autosave directory. Skipping OPML autosave.")
+            "Could not determine autosave directory. Skipping OPML autosave."
+        )
         return None
 
     try:
@@ -234,8 +234,8 @@ def _write_atomically_with_lock(autosave_path, opml_string):
             try:
                 os.remove(temp_path)
             except OSError as e:
-                logger.warning("Failed to remove temporary file %s: %s",
-                               temp_path, e)
+                logger.warning(
+                    "Failed to remove temporary file %s: %s", temp_path, e)
     return False
 
 

--- a/tests/unit/test_opml_import.py
+++ b/tests/unit/test_opml_import.py
@@ -74,9 +74,9 @@ def test_import_nested_opml(client, mocker):
                  return_value=True)
 
     data = {"file": (io.BytesIO(opml_content), "nested.opml")}
-    response = client.post("/api/opml/import",
-                           data=data,
-                           content_type="multipart/form-data")
+    response = client.post(
+        "/api/opml/import", data=data, content_type="multipart/form-data"
+    )
 
     assert response.status_code == 200
     result = response.get_json()
@@ -92,8 +92,9 @@ def test_import_nested_opml(client, mocker):
         assert sub_tech_tab is not None
 
         # Verify affected_tab_ids
-        assert {tech_tab.id, sub_tech_tab.id,
-                result["tab_id"]}.issubset(set(result["affected_tab_ids"]))
+        assert {tech_tab.id, sub_tech_tab.id, result["tab_id"]}.issubset(
+            set(result["affected_tab_ids"])
+        )
 
         # Check feeds
         hn_feed = Feed.query.filter_by(
@@ -158,7 +159,8 @@ def test_opml_import_skips_skipped_folder_types(client, mocker):
 
         # Assert that the feed in the skipped folder was not created
         skipped_feed = Feed.query.filter_by(
-            url="https://example.com/should-not-import.xml").first()
+            url="https://example.com/should-not-import.xml"
+        ).first()
         assert skipped_feed is None
 
 
@@ -248,8 +250,11 @@ def test_opml_import_skips_duplicate_feed_urls(client, mocker):
 
     with app.app_context():
         # Confirm that we still only have one feed per URL overall.
-        feeds_by_url = (Feed.query.with_entities(Feed.url, func.count(
-            Feed.id)).group_by(Feed.url).all())
+        feeds_by_url = (
+            Feed.query.with_entities(Feed.url, func.count(Feed.id))
+            .group_by(Feed.url)
+            .all()
+        )
 
         counts = dict(feeds_by_url)
         assert counts["https://example.com/existing.xml"] == 1
@@ -389,6 +394,7 @@ def test_import_malformed_opml(client):
     payload = response.get_json()
     assert "Malformed OPML file" in payload.get("error", "")
 
+
 def test_import_opml_txt_file_rejected(client):
     """Test importing a .txt file is rejected."""
     txt_content = b"This is just a text file, not an OPML."
@@ -402,4 +408,5 @@ def test_import_opml_txt_file_rejected(client):
     )
     assert response.status_code == 400
     payload = response.get_json()
-    assert "Invalid file type. Allowed: .opml, .xml" in payload.get("error", "")
+    assert "Invalid file type. Allowed: .opml, .xml" in payload.get(
+        "error", "")

--- a/tests/unit/test_opml_import.py
+++ b/tests/unit/test_opml_import.py
@@ -388,3 +388,18 @@ def test_import_malformed_opml(client):
 
     payload = response.get_json()
     assert "Malformed OPML file" in payload.get("error", "")
+
+def test_import_opml_txt_file_rejected(client):
+    """Test importing a .txt file is rejected."""
+    txt_content = b"This is just a text file, not an OPML."
+    data = {
+        "file": (io.BytesIO(txt_content), "feeds.txt"),
+    }
+    response = client.post(
+        "/api/opml/import",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert "Invalid file type. Allowed: .opml, .xml" in payload.get("error", "")


### PR DESCRIPTION
This PR removes `.txt` from `allowed_extensions` during OPML import to strictly
enforce file validation and prevent arbitrary file processing. Also adds a regression test.

---
*PR created automatically by Jules for task [8861543342621437](https://jules.google.com/task/8861543342621437) started by @sheepdestroyer*

## Summary by Sourcery

Tighten OPML import file-type validation to reject .txt uploads and document the expected error response in tests.

Bug Fixes:
- Disallow .txt files during OPML import to prevent processing non-OPML content.

Tests:
- Add a regression test asserting that .txt OPML import attempts return HTTP 400 with the correct invalid file type error message.