### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF vulnerability on OPML import

### DIFF
--- a/backend/blueprints/opml.py
+++ b/backend/blueprints/opml.py
@@ -38,8 +38,8 @@ def _generate_opml_string(tabs=None):
 
     if tabs is None:
         # Eager load feeds to avoid N+1 queries
-        tabs = Tab.query.options(selectinload(Tab.feeds)).order_by(
-            Tab.order).all()
+        tabs = Tab.query.options(selectinload(
+            Tab.feeds)).order_by(Tab.order).all()
 
     for tab in tabs:
         # Skip tabs with no feeds
@@ -65,10 +65,9 @@ def _generate_opml_string(tabs=None):
 
     # Use unsafe_tostring because we are strictly generating XML, not parsing it.
     # We encode to utf-8 and decode to unicode to ensure a correct XML declaration.
-    opml_string = unsafe_tostring(opml_element,
-                                  encoding="utf-8",
-                                  method="xml",
-                                  xml_declaration=True).decode("utf-8")
+    opml_string = unsafe_tostring(
+        opml_element, encoding="utf-8", method="xml", xml_declaration=True
+    ).decode("utf-8")
 
     feed_count = sum(len(tab.feeds) for tab in tabs)
     tab_count = sum(1 for tab in tabs if tab.feeds)
@@ -82,8 +81,7 @@ def _validate_opml_file_request():
         return None, (jsonify({"error": "No file part in the request"}), 400)
     opml_file = request.files["file"]
     if opml_file.filename == "":
-        return None, (jsonify({"error":
-                               "No file selected for uploading"}), 400)
+        return None, (jsonify({"error": "No file selected for uploading"}), 400)
     if not opml_file:
         return None, (jsonify({"error": "File object is empty"}), 400)
 
@@ -109,7 +107,14 @@ def import_opml():
     """Imports feeds from an OPML file, supporting nested structures as new tabs."""
     # CSRF protection: require a specific header to prevent simple HTML form submissions
     if request.headers.get("X-Requested-With") != "XMLHttpRequest":
-        return jsonify({"error": "Missing or invalid X-Requested-With header (CSRF protection)"}), 400
+        return (
+            jsonify(
+                {
+                    "error": "Missing or invalid X-Requested-With header (CSRF protection)"
+                }
+            ),
+            400,
+        )
 
     opml_file, error_resp = _validate_opml_file_request()
     if error_resp:
@@ -118,8 +123,8 @@ def import_opml():
     requested_tab_id_str = request.form.get("tab_id")
 
     # Call the service function
-    result, error_info = import_opml_service(opml_file.stream,
-                                             requested_tab_id_str)
+    result, error_info = import_opml_service(
+        opml_file.stream, requested_tab_id_str)
 
     if error_info:
         error_json, status_code = error_info
@@ -147,7 +152,8 @@ def export_opml():
 
     response = Response(opml_string, mimetype="application/xml")
     response.headers["Content-Disposition"] = (
-        'attachment; filename="sheepvibes_feeds.opml"')
+        'attachment; filename="sheepvibes_feeds.opml"'
+    )
 
     logger.info(
         "Successfully generated OPML export for %d feeds across %d tabs.",
@@ -182,12 +188,12 @@ def _get_autosave_directory():
                 abs_db_path = os.path.abspath(db_path)
                 data_dir = os.path.dirname(abs_db_path)
                 logger.debug(
-                    "Resolved autosave directory from SQLite path: %s",
-                    data_dir)
+                    "Resolved autosave directory from SQLite path: %s", data_dir
+                )
             except Exception:
                 logger.warning(
-                    "Could not resolve absolute path for SQLite DB: %s",
-                    db_path)
+                    "Could not resolve absolute path for SQLite DB: %s", db_path
+                )
 
     if not data_dir:
         # 3. Fall back to PROJECT_ROOT/data
@@ -197,7 +203,8 @@ def _get_autosave_directory():
 
     if not data_dir:
         logger.warning(
-            "Could not determine autosave directory. Skipping OPML autosave.")
+            "Could not determine autosave directory. Skipping OPML autosave."
+        )
         return None
 
     try:
@@ -238,8 +245,8 @@ def _write_atomically_with_lock(autosave_path, opml_string):
             try:
                 os.remove(temp_path)
             except OSError as e:
-                logger.warning("Failed to remove temporary file %s: %s",
-                               temp_path, e)
+                logger.warning(
+                    "Failed to remove temporary file %s: %s", temp_path, e)
     return False
 
 

--- a/backend/blueprints/opml.py
+++ b/backend/blueprints/opml.py
@@ -107,6 +107,10 @@ def _validate_opml_file_request():
 @opml_bp.route("/import", methods=["POST"])
 def import_opml():
     """Imports feeds from an OPML file, supporting nested structures as new tabs."""
+    # CSRF protection: require a specific header to prevent simple HTML form submissions
+    if request.headers.get("X-Requested-With") != "XMLHttpRequest":
+        return jsonify({"error": "Missing or invalid X-Requested-With header (CSRF protection)"}), 400
+
     opml_file, error_resp = _validate_opml_file_request()
     if error_resp:
         return error_resp

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -88,6 +88,9 @@ export const api = {
     exportOpml: () => fetchData('/api/opml/export', { method: 'GET' }, 'text'),
     importOpml: (formData) => fetchData('/api/opml/import', {
         method: 'POST',
+        headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+        },
         body: formData
     })
 };

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -172,7 +172,9 @@ async function loadFeedsForTab(tabId) {
             const msg = document.createElement('div');
             msg.className = 'feed-widget empty-tab-message'; // Reuse class but add distinct marker
             msg.dataset.tabId = tabId;
-            msg.innerHTML = '<p>No feeds found for this tab. Add one using the form above!</p>';
+            const p = document.createElement('p');
+            p.textContent = 'No feeds found for this tab. Add one using the form above!';
+            msg.appendChild(p);
             feedGrid.appendChild(msg);
         }
         loadedTabs.add(tabId);

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -155,7 +155,9 @@ export function createFeedWidget(feed, callbacks) {
         });
         itemList.appendChild(fragment);
     } else {
-        itemList.innerHTML = '<li>No items found for this feed.</li>';
+        const li = document.createElement('li');
+        li.textContent = 'No items found for this feed.';
+        itemList.replaceChildren(li);
     }
 
     // Programmatically trigger a scroll event to handle cases where the initial
@@ -196,12 +198,18 @@ export function renderTabs(tabs, activeTabId, callbacks) {
     const renameTabButton = document.getElementById('rename-tab-button');
     const deleteTabButton = document.getElementById('delete-tab-button');
 
-    tabsContainer.innerHTML = '';
+    tabsContainer.replaceChildren();
     if (!tabs || tabs.length === 0) {
-        tabsContainer.innerHTML = '<span>No tabs found.</span>';
+        const span = document.createElement('span');
+        span.textContent = 'No tabs found.';
+        tabsContainer.appendChild(span);
         renameTabButton.disabled = true;
         deleteTabButton.disabled = true;
-        feedGrid.innerHTML = '<p>Create a tab to get started!</p>';
+
+        const p = document.createElement('p');
+        p.textContent = 'Create a tab to get started!';
+        feedGrid.replaceChildren(p);
+
         return { activeTabId: null };
     }
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1605,7 +1605,7 @@ def test_import_opml_success(mock_fetch_update, client):
             "file": opml_file,
             "tab_id": str(tab_id)
         },
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     # Assert
@@ -1677,7 +1677,7 @@ def test_import_opml_with_duplicates(mock_fetch_update, client):
             "file": opml_file,
             "tab_id": str(tab_id)
         },
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -1695,7 +1695,7 @@ def test_import_opml_with_duplicates(mock_fetch_update, client):
 def test_import_opml_no_file(client):
     """Test POST /api/opml/import without a file."""
     response = client.post("/api/opml/import",
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
     assert response.status_code == 400
     assert "No file part" in response.json["error"]
 
@@ -1705,7 +1705,7 @@ def test_import_opml_empty_filename(client):
     opml_file = (io.BytesIO(b"content"), "")  # Empty filename
     response = client.post("/api/opml/import",
                            data={"file": opml_file},
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
     assert response.status_code == 400
     assert "No file selected" in response.json["error"]
 
@@ -1721,7 +1721,7 @@ def test_import_opml_malformed_xml(client):
     opml_file = (io.BytesIO(opml_content.encode("utf-8")), "malformed.opml")
     response = client.post("/api/opml/import",
                            data={"file": opml_file},
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
     assert response.status_code == 400
     assert "Malformed OPML file" in response.json["error"]
 
@@ -1750,7 +1750,7 @@ def test_import_opml_creates_default_tab_when_none_exist(
     # Act
     response = client.post("/api/opml/import",
                            data={"file": opml_file},
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
 
     # Assert
     assert response.status_code == 200
@@ -1814,7 +1814,7 @@ def test_import_opml_specific_tab(mock_fetch_update, client):
             "file": opml_file,
             "tab_id": str(tab2_id)
         },
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -1857,7 +1857,7 @@ def test_import_opml_default_tab_if_tab_id_not_provided(
     # Not providing 'tab_id' in the form data
     response = client.post("/api/opml/import",
                            data={"file": opml_file},
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
 
     assert response.status_code == 200
     json_data = response.json
@@ -1909,7 +1909,7 @@ def test_import_opml_missing_xmlurl_is_skipped(mock_fetch_update_unused,
             "file": opml_file,
             "tab_id": str(tab_id)
         },
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -1943,7 +1943,7 @@ def test_import_opml_no_body_tag(mock_fetch_update_unused, client):
     opml_file = (io.BytesIO(opml_content.encode("utf-8")), "no_body.opml")
     response = client.post("/api/opml/import",
                            data={"file": opml_file},
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
 
     assert response.status_code == 200  # Should still be a valid request
     json_data = response.json
@@ -1965,7 +1965,7 @@ def test_import_opml_empty_body_tag(mock_fetch_update_unused, client):
     opml_file = (io.BytesIO(opml_content.encode("utf-8")), "empty_body.opml")
     response = client.post("/api/opml/import",
                            data={"file": opml_file},
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
 
     assert response.status_code == 200
     json_data = response.json
@@ -2008,7 +2008,7 @@ def test_import_opml_nested_structure_creates_tabs_and_feeds(
     # Act: Import without specifying a tab_id, relying on default tab creation if none exist
     response = client.post("/api/opml/import",
                            data={"file": opml_file},
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
 
     # Assert
     assert response.status_code == 200
@@ -2078,7 +2078,7 @@ def test_import_opml_nested_folder_name_matches_existing_tab(
     )
     response = client.post("/api/opml/import",
                            data={"file": opml_file},
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
 
     assert response.status_code == 200
     json_data = response.json
@@ -2111,7 +2111,7 @@ def test_import_opml_empty_folder(mock_fetch_update_unused, client):
                  "empty_folder_import.opml")
     response = client.post("/api/opml/import",
                            data={"file": opml_file},
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
 
     assert response.status_code == 200
     json_data = response.json
@@ -2172,7 +2172,7 @@ def test_import_opml_folder_with_no_title_is_skipped_children_go_to_default(
             "file": opml_file,
             "tab_id": str(initial_tab_id)
         },
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -2227,7 +2227,7 @@ def test_import_opml_deletes_empty_default_imported_feeds_tab(
     )
     response = client.post("/api/opml/import",
                            data={"file": opml_file},
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
 
     assert response.status_code == 200
     data = response.json

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -12,7 +12,8 @@ import pytest
 # Need to configure the app for testing
 from backend.app import app, cache  # Import the app and cache instance
 from backend.feed_service import (  # For new tests
-    parse_published_time, process_feed_entries,
+    parse_published_time,
+    process_feed_entries,
 )
 from backend.models import Feed, FeedItem, Tab, db  # Import models directly
 
@@ -44,7 +45,8 @@ def client():
 
     # Get the Redis URL set by pytest-env from pytest.ini
     redis_url = os.environ.get(
-        "CACHE_REDIS_URL", "redis://localhost:6379/0")  # Default if not set
+        "CACHE_REDIS_URL", "redis://localhost:6379/0"
+    )  # Default if not set
 
     # Force IPv4 for localhost if it's being used.
     if "localhost" in redis_url:
@@ -365,8 +367,7 @@ def test_get_feeds_for_tab_with_items_and_limit(client, setup_tabs_and_feeds):
     assert len(feed2_data["items"]) == 1  # Limited to 1
 
 
-def test_get_feeds_for_tab_with_feed_having_no_items(client,
-                                                     setup_tabs_and_feeds):
+def test_get_feeds_for_tab_with_feed_having_no_items(client, setup_tabs_and_feeds):
     """Test GET /api/tabs/<tab_id>/feeds for a tab with a feed that has no items."""
     tab2_id = setup_tabs_and_feeds["tab2_id"]
 
@@ -408,12 +409,15 @@ def test_get_feeds_for_tab_not_found(client):
 
 
 # Mock feed fetching/processing for add/delete tests
-@patch("backend.blueprints.feeds.fetch_feed"
-       )  # Patch fetch_feed where it's used in app.py
-@patch("backend.blueprints.feeds.process_feed_entries"
-       )  # Patch process_feed_entries where it's used in app.py
-def test_add_feed_success(mock_process_entries, mock_fetch, client,
-                          setup_tabs_and_feeds):
+@patch(
+    "backend.blueprints.feeds.fetch_feed"
+)  # Patch fetch_feed where it's used in app.py
+@patch(
+    "backend.blueprints.feeds.process_feed_entries"
+)  # Patch process_feed_entries where it's used in app.py
+def test_add_feed_success(
+    mock_process_entries, mock_fetch, client, setup_tabs_and_feeds
+):
     """Test POST /api/feeds successfully adding a feed."""
     # Arrange
     tab1_id = setup_tabs_and_feeds["tab1_id"]
@@ -426,11 +430,8 @@ def test_add_feed_success(mock_process_entries, mock_fetch, client,
     mock_process_entries.return_value = 0
 
     # Act
-    response = client.post("/api/feeds",
-                           json={
-                               "url": feed_url,
-                               "tab_id": tab1_id
-                           })
+    response = client.post(
+        "/api/feeds", json={"url": feed_url, "tab_id": tab1_id})
 
     # Assert
     assert response.status_code == 201
@@ -457,11 +458,8 @@ def test_add_feed_fetch_fails(mock_fetch, client, setup_tabs_and_feeds):
     feed_url = "http://badsite.com/rss"
     mock_fetch.return_value = None  # Simulate fetch failure
 
-    response = client.post("/api/feeds",
-                           json={
-                               "url": feed_url,
-                               "tab_id": tab1_id
-                           })
+    response = client.post(
+        "/api/feeds", json={"url": feed_url, "tab_id": tab1_id})
 
     assert response.status_code == 201
     # Uses URL as name on fetch failure
@@ -476,11 +474,8 @@ def test_add_feed_duplicate_url(mock_fetch, client, setup_tabs_and_feeds):
     tab1_id = setup_tabs_and_feeds["tab1_id"]
     existing_url = "url1"  # From setup_tabs_and_feeds
 
-    response = client.post("/api/feeds",
-                           json={
-                               "url": existing_url,
-                               "tab_id": tab1_id
-                           })
+    response = client.post(
+        "/api/feeds", json={"url": existing_url, "tab_id": tab1_id})
 
     assert response.status_code == 409  # Conflict
     assert "error" in response.json
@@ -490,11 +485,8 @@ def test_add_feed_duplicate_url(mock_fetch, client, setup_tabs_and_feeds):
 
 def test_add_feed_invalid_tab(client):
     """Test POST /api/feeds with a non-existent tab_id."""
-    response = client.post("/api/feeds",
-                           json={
-                               "url": "some_url",
-                               "tab_id": 999
-                           })
+    response = client.post(
+        "/api/feeds", json={"url": "some_url", "tab_id": 999})
     assert response.status_code == 404
 
 
@@ -575,12 +567,11 @@ def test_mark_item_read_not_found(client):
 
 
 @patch("backend.blueprints.feeds.fetch_and_update_feed")
-def test_update_feed_success(mock_fetch_and_update, client,
-                             setup_tabs_and_feeds):
+def test_update_feed_success(mock_fetch_and_update, client, setup_tabs_and_feeds):
     feed_id = setup_tabs_and_feeds["feed1_id"]
     # Mock the return values of fetch_and_update_feed
-    mock_fetch_and_update.return_value = (True, 1, 1
-                                          )  # success, num_new_items, tab_id
+    mock_fetch_and_update.return_value = (
+        True, 1, 1)  # success, num_new_items, tab_id
 
     response = client.post(f"/api/feeds/{feed_id}/update")
 
@@ -600,8 +591,7 @@ def test_update_feed_not_found(mock_fetch_and_update, client):
 
 
 @patch("backend.blueprints.feeds.fetch_and_update_feed")
-def test_update_feed_failure(mock_fetch_and_update, client,
-                             setup_tabs_and_feeds):
+def test_update_feed_failure(mock_fetch_and_update, client, setup_tabs_and_feeds):
     feed_id = setup_tabs_and_feeds["feed1_id"]
     mock_fetch_and_update.side_effect = Exception("Simulated update error")
 
@@ -611,7 +601,8 @@ def test_update_feed_failure(mock_fetch_and_update, client,
     assert "error" in response.json
     assert (
         f"An internal error occurred while manually updating feed {feed_id}."
-        in response.json["error"])
+        in response.json["error"]
+    )
     mock_fetch_and_update.assert_called_once_with(feed_id)
 
 
@@ -619,8 +610,7 @@ def test_update_feed_failure(mock_fetch_and_update, client,
 
 
 @patch("backend.blueprints.feeds.fetch_feed")
-def test_update_feed_url_success(mock_fetch_feed, client,
-                                 setup_tabs_and_feeds):
+def test_update_feed_url_success(mock_fetch_feed, client, setup_tabs_and_feeds):
     """Test PUT /api/feeds/<feed_id> successfully updates feed URL and name."""
     feed_id = setup_tabs_and_feeds["feed1_id"]
     new_url = "https://example.com/new-feed.xml"
@@ -643,8 +633,7 @@ def test_update_feed_url_success(mock_fetch_feed, client,
 
 
 @patch("backend.blueprints.feeds.fetch_feed")
-def test_update_feed_url_fetch_fails(mock_fetch_feed, client,
-                                     setup_tabs_and_feeds):
+def test_update_feed_url_fetch_fails(mock_fetch_feed, client, setup_tabs_and_feeds):
     """Test PUT /api/feeds/<feed_id> when feed fetch fails."""
     feed_id = setup_tabs_and_feeds["feed1_id"]
     new_url = "https://example.com/invalid-feed.xml"
@@ -691,8 +680,9 @@ def test_update_feed_url_duplicate_url(client, setup_tabs_and_feeds):
 
 def test_update_feed_url_not_found(client):
     """Test PUT /api/feeds/<feed_id> when feed is not found."""
-    response = client.put("/api/feeds/999",
-                          json={"url": "https://example.com/new-feed.xml"})
+    response = client.put(
+        "/api/feeds/999", json={"url": "https://example.com/new-feed.xml"}
+    )
 
     assert response.status_code == 404
 
@@ -704,8 +694,9 @@ def test_get_root_path(client):
     """Test GET / (root path) serves index.html."""
     response = client.get("/")
     assert response.status_code == 200
-    assert (response.content_type == "text/html; charset=utf-8"
-            )  # Flask default for send_from_directory
+    assert (
+        response.content_type == "text/html; charset=utf-8"
+    )  # Flask default for send_from_directory
     assert b"<title>SheepVibes</title>" in response.data
 
 
@@ -743,8 +734,7 @@ def test_get_non_existent_static_file(client):
 
 @patch("backend.blueprints.feeds.announcer.announce")
 @patch("backend.blueprints.feeds.update_all_feeds")
-def test_update_all_feeds_success(mock_update_all_feeds, mock_announce,
-                                  client):
+def test_update_all_feeds_success(mock_update_all_feeds, mock_announce, client):
     """Test POST /api/feeds/update_all success path."""
     # Arrange
     mock_update_all_feeds.return_value = (1, 1, {1})
@@ -776,8 +766,8 @@ def test_update_all_feeds_success(mock_update_all_feeds, mock_announce,
 @patch("backend.feed_service._fetch_feed_content")
 @patch("backend.feed_service.Feed")
 def test_feed_service_update_all_feeds_emits_progress_events(
-        mock_feed_model, mock_fetch_feed_content, mock_process_fetch_result,
-        mock_announce):
+    mock_feed_model, mock_fetch_feed_content, mock_process_fetch_result, mock_announce
+):
     """Unit test for feed_service.update_all_feeds SSE progress events."""
     from backend import feed_service
 
@@ -803,7 +793,8 @@ def test_feed_service_update_all_feeds_emits_progress_events(
 
     messages = [
         json.loads(call.kwargs["msg"].replace("data: ", "").strip())
-        for call in calls if "msg" in call.kwargs
+        for call in calls
+        if "msg" in call.kwargs
     ]
 
     # Initial progress event
@@ -812,7 +803,7 @@ def test_feed_service_update_all_feeds_emits_progress_events(
     assert messages[0]["max"] == len(feeds)
 
     # Per-feed progress events
-    per_feed_payloads = messages[1:1 + len(feeds)]
+    per_feed_payloads = messages[1: 1 + len(feeds)]
     assert len(per_feed_payloads) == len(feeds)
     for index, payload in enumerate(per_feed_payloads, start=1):
         assert payload["value"] == index
@@ -824,8 +815,7 @@ def test_feed_service_update_all_feeds_emits_progress_events(
 
 @patch("backend.blueprints.feeds.announcer.announce")
 @patch("backend.blueprints.feeds.update_all_feeds")
-def test_update_all_feeds_exception(mock_update_all_feeds, mock_announce,
-                                    client):
+def test_update_all_feeds_exception(mock_update_all_feeds, mock_announce, client):
     """Test POST /api/feeds/update-all when update_all_feeds raises an exception."""
     # Arrange
     mock_update_all_feeds.side_effect = Exception("Test update error")
@@ -837,8 +827,7 @@ def test_update_all_feeds_exception(mock_update_all_feeds, mock_announce,
     assert response.status_code == 500
     data = response.get_json()
     assert "error" in data
-    assert "An internal error occurred while updating all feeds." in data[
-        "error"]
+    assert "An internal error occurred while updating all feeds." in data["error"]
 
     # Assert Mocks
     mock_update_all_feeds.assert_called_once()
@@ -887,8 +876,9 @@ def test_cache_invalidation_flow(client, setup_tabs_and_feeds):
         client.post(f"/api/items/{item1_id}/read")
 
         # 5. Assert the query IS re-executed on the next call (cache miss).
-        with patch("backend.extensions.db.session.execute"
-                   ) as mock_execute_after_invalidation:
+        with patch(
+            "backend.extensions.db.session.execute"
+        ) as mock_execute_after_invalidation:
             client.get(f"/api/tabs/{tab1_id}/feeds")
             mock_execute_after_invalidation.assert_called()
 
@@ -910,19 +900,18 @@ def test_cache_invalidation_flow(client, setup_tabs_and_feeds):
         client.post("/api/tabs", json={"name": "A New Tab"})
 
         # 5. Assert the next call is a cache miss
-        with patch("backend.models.Tab.query"
-                   ) as mock_tab_query_after_invalidation:
+        with patch("backend.models.Tab.query") as mock_tab_query_after_invalidation:
             mock_tab_query_after_invalidation.order_by.return_value.all.return_value = []
             client.get("/api/tabs")
-            mock_tab_query_after_invalidation.order_by.return_value.all.assert_called_once(
-            )
+            mock_tab_query_after_invalidation.order_by.return_value.all.assert_called_once()
 
 
 # --- Tests for Model Methods ---
 
 
 def test_feed_item_to_dict_serialization(
-        client, ):  # client fixture ensures app_context and db setup
+    client,
+):  # client fixture ensures app_context and db setup
     """
     Tests the to_dict() method of the FeedItem model, focusing on datetime serialization.
     """
@@ -973,20 +962,12 @@ def test_feed_item_to_dict_serialization(
         # EST is UTC-5, PST is UTC-8
         tz_est = datetime.timezone(datetime.timedelta(hours=-5))
         tz_pst = datetime.timezone(datetime.timedelta(hours=-8))
-        dt_aware_published_est = datetime.datetime(2023,
-                                                   3,
-                                                   15,
-                                                   12,
-                                                   0,
-                                                   0,
-                                                   tzinfo=tz_est)  # 17:00 UTC
-        dt_aware_fetched_pst = datetime.datetime(2023,
-                                                 3,
-                                                 15,
-                                                 9,
-                                                 0,
-                                                 0,
-                                                 tzinfo=tz_pst)  # 17:00 UTC
+        dt_aware_published_est = datetime.datetime(
+            2023, 3, 15, 12, 0, 0, tzinfo=tz_est
+        )  # 17:00 UTC
+        dt_aware_fetched_pst = datetime.datetime(
+            2023, 3, 15, 9, 0, 0, tzinfo=tz_pst
+        )  # 17:00 UTC
 
         item_aware = FeedItem(
             feed_id=test_feed.id,
@@ -1013,13 +994,9 @@ def test_feed_item_to_dict_serialization(
         db.session.commit()
 
         # Scenario 3: published_time is None, fetched_time is aware UTC
-        dt_aware_fetched_utc = datetime.datetime(2023,
-                                                 5,
-                                                 20,
-                                                 14,
-                                                 0,
-                                                 0,
-                                                 tzinfo=datetime.timezone.utc)
+        dt_aware_fetched_utc = datetime.datetime(
+            2023, 5, 20, 14, 0, 0, tzinfo=datetime.timezone.utc
+        )
         item_none_published = FeedItem(
             feed_id=test_feed.id,
             title="None Published Test",
@@ -1048,18 +1025,15 @@ def test_to_iso_z_string_static_method():
 
     # 2. Test with a timezone-aware datetime (not UTC)
     tz_est = datetime.timezone(datetime.timedelta(hours=-5))
-    aware_dt_est = datetime.datetime(2023, 3, 15, 10, 0, 0,
-                                     tzinfo=tz_est)  # This is 15:00 UTC
+    aware_dt_est = datetime.datetime(
+        2023, 3, 15, 10, 0, 0, tzinfo=tz_est
+    )  # This is 15:00 UTC
     assert FeedItem.to_iso_z_string(aware_dt_est) == "2023-03-15T15:00:00Z"
 
     # 3. Test with a timezone-aware UTC datetime
-    aware_dt_utc = datetime.datetime(2023,
-                                     5,
-                                     20,
-                                     14,
-                                     30,
-                                     0,
-                                     tzinfo=datetime.timezone.utc)
+    aware_dt_utc = datetime.datetime(
+        2023, 5, 20, 14, 30, 0, tzinfo=datetime.timezone.utc
+    )
     assert FeedItem.to_iso_z_string(aware_dt_utc) == "2023-05-20T14:30:00Z"
 
     # 4. Test with None input
@@ -1130,7 +1104,8 @@ if _dst_tz is not None:
             datetime.datetime(2023, 6, 15, 14, 0, 0),
             True,
             id="aware_dst_america_new_york",
-        ))
+        )
+    )
 
 # Edge-case: custom tzinfo with utcoffset() returning None
 # Current behavior: returned as-is (tzinfo still attached, not naive)
@@ -1140,11 +1115,11 @@ _VALIDATE_UTC_CASES.append(
         _no_offset_dt,
         False,  # expect_naive=False => tzinfo still attached
         id="custom_tzinfo_utcoffset_none",
-    ))
+    )
+)
 
 
-@pytest.mark.parametrize("input_dt, expected_dt, expect_naive",
-                         _VALIDATE_UTC_CASES)
+@pytest.mark.parametrize("input_dt, expected_dt, expect_naive", _VALIDATE_UTC_CASES)
 def test_validate_datetime_utc_validator(input_dt, expected_dt, expect_naive):
     """Tests the FeedItem.validate_datetime_utc validator method."""
     item = FeedItem()
@@ -1159,8 +1134,7 @@ def test_validate_datetime_utc_validator(input_dt, expected_dt, expect_naive):
 # --- Tests for feed_service functions ---
 
 
-def test_parse_published_time_variations(
-):  # No client fixture needed as it's a pure function
+def test_parse_published_time_variations():  # No client fixture needed as it's a pure function
     """Tests the parse_published_time helper with various entry structures."""
 
     mock_spec = ["published_parsed", "published", "updated", "created", "get"]
@@ -1168,7 +1142,8 @@ def test_parse_published_time_variations(
     # Case 1: 'published_parsed' available and valid
     entry1 = MagicMock(spec=mock_spec)
     entry1.published_parsed = datetime.datetime(
-        2023, 10, 26, 14, 30, 0, tzinfo=timezone.utc).utctimetuple()
+        2023, 10, 26, 14, 30, 0, tzinfo=timezone.utc
+    ).utctimetuple()
     entry1.published = None
     entry1.updated = None
     entry1.created = None
@@ -1266,7 +1241,8 @@ def test_parse_published_time_variations(
 
 
 def test_process_feed_with_in_batch_duplicate_guids(
-        client, ):  # Using client fixture for app_context
+    client,
+):  # Using client fixture for app_context
     """
     Tests that process_feed_entries correctly handles entries with duplicate GUIDs
     within the same fetched batch, only adding the first instance.
@@ -1294,29 +1270,16 @@ def test_process_feed_with_in_batch_duplicate_guids(
         # Adjust .get to correctly return explicitly set attributes or the default
         mock_parsed_feed.feed.get = lambda key, default_val=None: (
             getattr(mock_parsed_feed.feed, key)
-            if hasattr(mock_parsed_feed.feed, key) else default_val)
+            if hasattr(mock_parsed_feed.feed, key)
+            else default_val
+        )
 
-        dt_entry1 = datetime.datetime(2023,
-                                      1,
-                                      1,
-                                      12,
-                                      0,
-                                      0,
-                                      tzinfo=timezone.utc)
-        dt_entry2 = datetime.datetime(2023,
-                                      1,
-                                      1,
-                                      12,
-                                      5,
-                                      0,
-                                      tzinfo=timezone.utc)
-        dt_entry3 = datetime.datetime(2023,
-                                      1,
-                                      1,
-                                      12,
-                                      10,
-                                      0,
-                                      tzinfo=timezone.utc)
+        dt_entry1 = datetime.datetime(
+            2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        dt_entry2 = datetime.datetime(
+            2023, 1, 1, 12, 5, 0, tzinfo=timezone.utc)
+        dt_entry3 = datetime.datetime(
+            2023, 1, 1, 12, 10, 0, tzinfo=timezone.utc)
 
         entry1_data = {
             "id": "guid1",
@@ -1366,14 +1329,14 @@ def test_process_feed_with_in_batch_duplicate_guids(
         assert "guid2" in guids_in_db
         assert len(guids_in_db) == 2
 
-        item1_db = FeedItem.query.filter_by(guid="guid1",
-                                            feed_id=feed_obj.id).first()
+        item1_db = FeedItem.query.filter_by(
+            guid="guid1", feed_id=feed_obj.id).first()
         assert item1_db is not None
         assert item1_db.title == "Title 2 (Same GUID)"
         assert item1_db.link == "http://link2.com"
 
-        item2_db = FeedItem.query.filter_by(guid="guid2",
-                                            feed_id=feed_obj.id).first()
+        item2_db = FeedItem.query.filter_by(
+            guid="guid2", feed_id=feed_obj.id).first()
         assert item2_db is not None
         assert item2_db.title == "Title 3"
         assert item2_db.link == "http://link3.com"
@@ -1408,23 +1371,15 @@ def test_process_feed_with_missing_link(client):
         # Adjust .get to correctly return explicitly set attributes or the default
         mock_parsed_feed.feed.get = lambda key, default_val=None: (
             getattr(mock_parsed_feed.feed, key)
-            if hasattr(mock_parsed_feed.feed, key) else default_val)
+            if hasattr(mock_parsed_feed.feed, key)
+            else default_val
+        )
 
         dt_valid = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-        dt_no_link = datetime.datetime(2023,
-                                       1,
-                                       1,
-                                       12,
-                                       5,
-                                       0,
-                                       tzinfo=timezone.utc)
-        dt_empty_link = datetime.datetime(2023,
-                                          1,
-                                          1,
-                                          12,
-                                          10,
-                                          0,
-                                          tzinfo=timezone.utc)
+        dt_no_link = datetime.datetime(
+            2023, 1, 1, 12, 5, 0, tzinfo=timezone.utc)
+        dt_empty_link = datetime.datetime(
+            2023, 1, 1, 12, 10, 0, tzinfo=timezone.utc)
 
         entry_valid_data = {
             "id": "guid_valid",
@@ -1453,16 +1408,17 @@ def test_process_feed_with_missing_link(client):
         entry_no_link = MagicMock()
         entry_no_link.configure_mock(**entry_no_link_data)
         entry_no_link.get = lambda key, default=None: entry_no_link_data.get(
-            key, default)
+            key, default
+        )
 
         entry_empty_link = MagicMock()
         entry_empty_link.configure_mock(**entry_empty_link_data)
         entry_empty_link.get = lambda key, default=None: entry_empty_link_data.get(
-            key, default)
+            key, default
+        )
 
         mock_parsed_feed.entries = [
-            entry_valid, entry_no_link, entry_empty_link
-        ]
+            entry_valid, entry_no_link, entry_empty_link]
         mock_parsed_feed.bozo = 0
 
         # 3. Call process_feed_entries directly
@@ -1486,8 +1442,10 @@ def test_export_opml_empty(client):
     response = client.get("/api/opml/export")
     assert response.status_code == 200
     assert "application/xml" in response.content_type
-    assert (response.headers["Content-Disposition"] ==
-            'attachment; filename="sheepvibes_feeds.opml"')
+    assert (
+        response.headers["Content-Disposition"]
+        == 'attachment; filename="sheepvibes_feeds.opml"'
+    )
 
     # Parse XML
     tree = ET.fromstring(response.data)
@@ -1513,8 +1471,10 @@ def test_export_opml_with_feeds(client, setup_tabs_and_feeds):
     response = client.get("/api/opml/export")
     assert response.status_code == 200
     assert "application/xml" in response.content_type
-    assert (response.headers["Content-Disposition"] ==
-            'attachment; filename="sheepvibes_feeds.opml"')
+    assert (
+        response.headers["Content-Disposition"]
+        == 'attachment; filename="sheepvibes_feeds.opml"'
+    )
 
     tree = ET.fromstring(response.data)
     assert tree.tag == "opml"
@@ -1601,11 +1561,9 @@ def test_import_opml_success(mock_fetch_update, client):
     # Act
     response = client.post(
         "/api/opml/import",
-        data={
-            "file": opml_file,
-            "tab_id": str(tab_id)
-        },
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        data={"file": opml_file, "tab_id": str(tab_id)},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     # Assert
@@ -1654,9 +1612,9 @@ def test_import_opml_with_duplicates(mock_fetch_update, client):
         db.session.commit()  # Commit tab first to get its ID
         tab_id = tab.id
 
-        existing_feed = Feed(tab_id=tab_id,
-                             name="Existing Feed",
-                             url="http://feed1.opml.com/rss")
+        existing_feed = Feed(
+            tab_id=tab_id, name="Existing Feed", url="http://feed1.opml.com/rss"
+        )
         db.session.add(existing_feed)
         db.session.commit()  # Commit the feed
 
@@ -1673,11 +1631,9 @@ def test_import_opml_with_duplicates(mock_fetch_update, client):
 
     response = client.post(
         "/api/opml/import",
-        data={
-            "file": opml_file,
-            "tab_id": str(tab_id)
-        },
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        data={"file": opml_file, "tab_id": str(tab_id)},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -1694,8 +1650,11 @@ def test_import_opml_with_duplicates(mock_fetch_update, client):
 
 def test_import_opml_no_file(client):
     """Test POST /api/opml/import without a file."""
-    response = client.post("/api/opml/import",
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
     assert response.status_code == 400
     assert "No file part" in response.json["error"]
 
@@ -1703,9 +1662,12 @@ def test_import_opml_no_file(client):
 def test_import_opml_empty_filename(client):
     """Test POST /api/opml/import with an empty filename (simulates no file selected)."""
     opml_file = (io.BytesIO(b"content"), "")  # Empty filename
-    response = client.post("/api/opml/import",
-                           data={"file": opml_file},
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data={"file": opml_file},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
     assert response.status_code == 400
     assert "No file selected" in response.json["error"]
 
@@ -1719,16 +1681,18 @@ def test_import_opml_malformed_xml(client):
 
     opml_content = "<opml><body/><head></opml>"  # Malformed, unclosed tags
     opml_file = (io.BytesIO(opml_content.encode("utf-8")), "malformed.opml")
-    response = client.post("/api/opml/import",
-                           data={"file": opml_file},
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data={"file": opml_file},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
     assert response.status_code == 400
     assert "Malformed OPML file" in response.json["error"]
 
 
 @patch("backend.feed_service.fetch_and_update_feed")
-def test_import_opml_creates_default_tab_when_none_exist(
-        mock_fetch_update, client):
+def test_import_opml_creates_default_tab_when_none_exist(mock_fetch_update, client):
     """Test import creates a default tab if none exist and imports feeds."""
     mock_fetch_update.return_value = (
         True,
@@ -1748,9 +1712,12 @@ def test_import_opml_creates_default_tab_when_none_exist(
                  "test_default_creation.opml")
 
     # Act
-    response = client.post("/api/opml/import",
-                           data={"file": opml_file},
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data={"file": opml_file},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
 
     # Assert
     assert response.status_code == 200
@@ -1810,11 +1777,9 @@ def test_import_opml_specific_tab(mock_fetch_update, client):
 
     response = client.post(
         "/api/opml/import",
-        data={
-            "file": opml_file,
-            "tab_id": str(tab2_id)
-        },
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        data={"file": opml_file, "tab_id": str(tab2_id)},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -1834,7 +1799,8 @@ def test_import_opml_specific_tab(mock_fetch_update, client):
 
 @patch("backend.feed_service.fetch_and_update_feed")
 def test_import_opml_default_tab_if_tab_id_not_provided(
-        mock_fetch_update, client):  # Added mock_fetch_update
+    mock_fetch_update, client
+):  # Added mock_fetch_update
     """Test POST /api/opml/import defaults to the first tab if tab_id is not provided."""
     mock_fetch_update.return_value = (
         True,
@@ -1855,9 +1821,12 @@ def test_import_opml_default_tab_if_tab_id_not_provided(
                  "test_default_tab.opml")
 
     # Not providing 'tab_id' in the form data
-    response = client.post("/api/opml/import",
-                           data={"file": opml_file},
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data={"file": opml_file},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
 
     assert response.status_code == 200
     json_data = response.json
@@ -1876,10 +1845,10 @@ def test_import_opml_default_tab_if_tab_id_not_provided(
         mock_fetch_update.assert_any_call(feed_in_default_tab.id)
 
 
-@patch("backend.feed_service.fetch_and_update_feed"
-       )  # Even though no feeds are imported, the setup could change.
-def test_import_opml_missing_xmlurl_is_skipped(mock_fetch_update_unused,
-                                               client):
+@patch(
+    "backend.feed_service.fetch_and_update_feed"
+)  # Even though no feeds are imported, the setup could change.
+def test_import_opml_missing_xmlurl_is_skipped(mock_fetch_update_unused, client):
     """Test that an <outline> missing xmlUrl is skipped during import."""
     mock_fetch_update_unused.return_value = (
         True,
@@ -1905,11 +1874,9 @@ def test_import_opml_missing_xmlurl_is_skipped(mock_fetch_update_unused,
                  "test_missing_xmlurl.opml")
     response = client.post(
         "/api/opml/import",
-        data={
-            "file": opml_file,
-            "tab_id": str(tab_id)
-        },
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        data={"file": opml_file, "tab_id": str(tab_id)},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -1941,9 +1908,12 @@ def test_import_opml_no_body_tag(mock_fetch_update_unused, client):
 
     opml_content = """<opml version="2.0"><head><title>No Body</title></head></opml>"""
     opml_file = (io.BytesIO(opml_content.encode("utf-8")), "no_body.opml")
-    response = client.post("/api/opml/import",
-                           data={"file": opml_file},
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data={"file": opml_file},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
 
     assert response.status_code == 200  # Should still be a valid request
     json_data = response.json
@@ -1963,23 +1933,24 @@ def test_import_opml_empty_body_tag(mock_fetch_update_unused, client):
 
     opml_content = """<opml version="2.0"><head><title>Empty Body</title></head><body></body></opml>"""
     opml_file = (io.BytesIO(opml_content.encode("utf-8")), "empty_body.opml")
-    response = client.post("/api/opml/import",
-                           data={"file": opml_file},
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data={"file": opml_file},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
 
     assert response.status_code == 200
     json_data = response.json
     assert json_data["imported_count"] == 0
     assert json_data["skipped_count"] == 0
     # Updated message for empty body elements (body exists but has no children)
-    assert "No feed entries or folders found in the OPML file." in json_data[
-        "message"]
+    assert "No feed entries or folders found in the OPML file." in json_data["message"]
     mock_fetch_update_unused.assert_not_called()
 
 
 @patch("backend.feed_service.fetch_and_update_feed")
-def test_import_opml_nested_structure_creates_tabs_and_feeds(
-        mock_fetch_update, client):
+def test_import_opml_nested_structure_creates_tabs_and_feeds(mock_fetch_update, client):
     """Tests that nested OPML outlines create new tabs and feeds are correctly assigned."""
     # Simulate successful fetch for each feed, returning a dummy tab_id (1)
     mock_fetch_update.side_effect = [
@@ -2006,9 +1977,12 @@ def test_import_opml_nested_structure_creates_tabs_and_feeds(
                  "nested_import.opml")
 
     # Act: Import without specifying a tab_id, relying on default tab creation if none exist
-    response = client.post("/api/opml/import",
-                           data={"file": opml_file},
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data={"file": opml_file},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
 
     # Assert
     assert response.status_code == 200
@@ -2025,7 +1999,8 @@ def test_import_opml_nested_structure_creates_tabs_and_feeds(
         tech_folder_tab = Tab.query.filter_by(name="Tech Folder").first()
         assert tech_folder_tab is not None
         default_tab = Tab.query.filter_by(
-            name="Imported Feeds").first()  # For the top-level feed
+            name="Imported Feeds"
+        ).first()  # For the top-level feed
         assert default_tab is not None
 
         # Verify feeds in "News Folder"
@@ -2053,8 +2028,7 @@ def test_import_opml_nested_structure_creates_tabs_and_feeds(
 
 
 @patch("backend.feed_service.fetch_and_update_feed")
-def test_import_opml_nested_folder_name_matches_existing_tab(
-        mock_fetch_update, client):
+def test_import_opml_nested_folder_name_matches_existing_tab(mock_fetch_update, client):
     """Tests that feeds in a folder are added to an existing tab if names match."""
     mock_fetch_update.return_value = (True, 1, 1)
     with app.app_context():
@@ -2076,9 +2050,12 @@ def test_import_opml_nested_folder_name_matches_existing_tab(
         io.BytesIO(opml_content.encode("utf-8")),
         "existing_folder_import.opml",
     )
-    response = client.post("/api/opml/import",
-                           data={"file": opml_file},
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data={"file": opml_file},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
 
     assert response.status_code == 200
     json_data = response.json
@@ -2109,9 +2086,12 @@ def test_import_opml_empty_folder(mock_fetch_update_unused, client):
     """
     opml_file = (io.BytesIO(opml_content.encode("utf-8")),
                  "empty_folder_import.opml")
-    response = client.post("/api/opml/import",
-                           data={"file": opml_file},
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data={"file": opml_file},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
 
     assert response.status_code == 200
     json_data = response.json
@@ -2119,8 +2099,9 @@ def test_import_opml_empty_folder(mock_fetch_update_unused, client):
 
     with app.app_context():
         empty_folder_tab = Tab.query.filter_by(name="Empty Folder").first()
-        assert (empty_folder_tab is None
-                )  # Corrected: Empty folders are skipped, no tab created
+        assert (
+            empty_folder_tab is None
+        )  # Corrected: Empty folders are skipped, no tab created
 
         # Check that the default tab for "Top Level Feed E" was created or used
         # If no other tabs existed, "Imported Feeds" would be created.
@@ -2144,7 +2125,8 @@ def test_import_opml_empty_folder(mock_fetch_update_unused, client):
 
 @patch("backend.feed_service.fetch_and_update_feed")
 def test_import_opml_folder_with_no_title_is_skipped_children_go_to_default(
-        mock_fetch_update, client):
+    mock_fetch_update, client
+):
     """Tests that a folder <outline> without a title is skipped, and its children go to the current default tab."""
     mock_fetch_update.return_value = (True, 1, 1)
     with app.app_context():  # Ensure a default tab exists or will be created
@@ -2168,11 +2150,9 @@ def test_import_opml_folder_with_no_title_is_skipped_children_go_to_default(
     # Import into the specific initial_tab_id to make assertions easier
     response = client.post(
         "/api/opml/import",
-        data={
-            "file": opml_file,
-            "tab_id": str(initial_tab_id)
-        },
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        data={"file": opml_file, "tab_id": str(initial_tab_id)},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -2186,8 +2166,10 @@ def test_import_opml_folder_with_no_title_is_skipped_children_go_to_default(
         initial_tab = db.session.get(Tab, initial_tab_id)
         assert initial_tab is not None
 
-        feeds_in_initial_tab = (Feed.query.filter_by(
-            tab_id=initial_tab_id).order_by(Feed.name).all())
+        feeds_in_initial_tab = (
+            Feed.query.filter_by(
+                tab_id=initial_tab_id).order_by(Feed.name).all()
+        )
         assert len(feeds_in_initial_tab) == 2
         assert feeds_in_initial_tab[0].name == "Feed E"
         assert feeds_in_initial_tab[1].name == "Feed F"
@@ -2199,16 +2181,16 @@ def test_import_opml_folder_with_no_title_is_skipped_children_go_to_default(
 
 @patch("backend.feed_service.fetch_and_update_feed")
 def test_import_opml_deletes_empty_default_imported_feeds_tab(
-        mock_fetch_update, client):  # Use client fixture for app context
+    mock_fetch_update, client
+):  # Use client fixture for app context
     """
     Tests that if 'Imported Feeds' is created because no tabs exist,
     but all OPML items go into folders (new tabs), the empty 'Imported Feeds' tab is deleted.
     """
-    mock_fetch_update.return_value = (True, 1, 1
-                                      )  # Simulate feed fetch success
+    mock_fetch_update.return_value = (
+        True, 1, 1)  # Simulate feed fetch success
     # Ensure no tabs exist initially. The `client` fixture already handles db cleanup.
-    with client.application.app_context(
-    ):  # Use client.application.app_context()
+    with client.application.app_context():  # Use client.application.app_context()
         assert Tab.query.count() == 0
 
     opml_content = """<?xml version="1.0" encoding="UTF-8"?>
@@ -2225,9 +2207,12 @@ def test_import_opml_deletes_empty_default_imported_feeds_tab(
         io.BytesIO(opml_content.encode("utf-8")),
         "test_delete_empty_default.opml",
     )
-    response = client.post("/api/opml/import",
-                           data={"file": opml_file},
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data={"file": opml_file},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
 
     assert response.status_code == 200
     data = response.json
@@ -2236,8 +2221,7 @@ def test_import_opml_deletes_empty_default_imported_feeds_tab(
     # The 'tab_name' in response might be "Imported Feeds" (the one that got deleted)
     # The 'tab_id' in response might be the ID of the deleted "Imported Feeds" tab.
 
-    with client.application.app_context(
-    ):  # Use client.application.app_context()
+    with client.application.app_context():  # Use client.application.app_context()
         tabs_after_import = Tab.query.all()
         # Only "My Folder" tab should exist. "Imported Feeds" should have been created and then deleted.
         assert len(tabs_after_import) == 1
@@ -2249,7 +2233,8 @@ def test_import_opml_deletes_empty_default_imported_feeds_tab(
         assert imported_feeds_tab_check is None
 
         feed_in_folder = Feed.query.filter_by(
-            url="http://example.com/folderfeed.xml").first()
+            url="http://example.com/folderfeed.xml"
+        ).first()
         assert feed_in_folder is not None
         assert feed_in_folder.tab.name == "My Folder"  # Associated with the correct tab
 
@@ -2311,8 +2296,9 @@ def test_get_feed_items_pagination_validation(client, setup_tabs_and_feeds):
     # Test limit exceeding maximum (should be capped, not error)
     response4 = client.get(f"/api/feeds/{feed_id}/items?offset=0&limit=200")
     assert response4.status_code == 200
-    assert (len(response4.json) == 2
-            )  # Should return available items, capped to MAX_PAGINATION_LIMIT
+    assert (
+        len(response4.json) == 2
+    )  # Should return available items, capped to MAX_PAGINATION_LIMIT
 
 
 def test_get_feed_items_pagination_limit_capping(client, setup_tabs_and_feeds):
@@ -2335,8 +2321,8 @@ def test_get_feed_items_pagination_limit_capping(client, setup_tabs_and_feeds):
                 title=f"Limit Cap Item {i}",
                 link=f"link_limit_cap_{i}",
                 guid=f"guid_limit_cap_{i}",
-                published_time=base_time -
-                timedelta(minutes=i),  # Newer items have later times
+                published_time=base_time
+                - timedelta(minutes=i),  # Newer items have later times
             )
             db.session.add(item)
         db.session.commit()
@@ -2362,9 +2348,9 @@ def setup_autosave_test_data(client):
         db.session.add(tab)
         db.session.commit()
 
-        feed = Feed(tab_id=tab.id,
-                    name="Autosave Feed",
-                    url="http://example.com/autosave")
+        feed = Feed(
+            tab_id=tab.id, name="Autosave Feed", url="http://example.com/autosave"
+        )
         db.session.add(feed)
         db.session.commit()
         return tab, feed
@@ -2399,7 +2385,8 @@ def test_autosave_opml_mocked(
 
     # Config app
     client.application.config["SQLALCHEMY_DATABASE_URI"] = (
-        "sqlite:////mock/data/sheepvibes.db")
+        "sqlite:////mock/data/sheepvibes.db"
+    )
     client.application.config["PROJECT_ROOT"] = "/mock"
 
     # Act
@@ -2414,14 +2401,15 @@ def test_autosave_opml_mocked(
     assert args[1] == "w"
 
     # Check lock
-    mock_lock.assert_called_once_with("/mock/data/sheepvibes_backup.opml.lock",
-                                      timeout=5)
+    mock_lock.assert_called_once_with(
+        "/mock/data/sheepvibes_backup.opml.lock", timeout=5
+    )
     mock_lock.return_value.__enter__.assert_called_once()
 
     # Check replacement
     mock_replace.assert_called_once_with(
-        "/mock/data/sheepvibes_backup.opml.tmp",
-        "/mock/data/sheepvibes_backup.opml")
+        "/mock/data/sheepvibes_backup.opml.tmp", "/mock/data/sheepvibes_backup.opml"
+    )
 
     # Check data written
     mock_file.write.assert_called_once()
@@ -2430,8 +2418,7 @@ def test_autosave_opml_mocked(
     assert "http://example.com/autosave" in written_data
 
 
-def test_autosave_opml_with_temp_fs(tmp_path, client,
-                                    setup_autosave_test_data):
+def test_autosave_opml_with_temp_fs(tmp_path, client, setup_autosave_test_data):
     """Test autosave_opml with a temporary file system, verifying file creation."""
     from backend.app import autosave_opml
 
@@ -2439,8 +2426,7 @@ def test_autosave_opml_with_temp_fs(tmp_path, client,
     # Note: data comes from the fixture (likely in-memory or default DB),
     # but we override the config so autosave_opml writes to our temp path.
     db_path = tmp_path / "sqlite.db"
-    client.application.config[
-        "SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_path}"
+    client.application.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_path}"
     client.application.config["PROJECT_ROOT"] = str(tmp_path)
 
     # Act
@@ -2451,7 +2437,8 @@ def test_autosave_opml_with_temp_fs(tmp_path, client,
     # since SQLALCHEMY_DATABASE_URI points to an absolute path
     backup_file_path = tmp_path / "sheepvibes_backup.opml"
     assert backup_file_path.exists(), (
-        "Backup file should have been created in the DB directory.")
+        "Backup file should have been created in the DB directory."
+    )
 
     written_data = backup_file_path.read_text(encoding="utf-8")
     assert "Autosave Test Tab" in written_data

--- a/tests/unit/test_opml_import.py
+++ b/tests/unit/test_opml_import.py
@@ -23,7 +23,12 @@ def test_import(client, mocker):
     # Mock the internal fetch_and_update_feed to avoid actual network calls
     mocker.patch("backend.feed_service.fetch_and_update_feed")
 
-    response = client.post(url, data=data, content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        url,
+        data=data,
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
 
     logger.info("Status Code: %s", response.status_code)
     assert response.status_code == 200
@@ -74,9 +79,12 @@ def test_import_nested_opml(client, mocker):
                  return_value=True)
 
     data = {"file": (io.BytesIO(opml_content), "nested.opml")}
-    response = client.post("/api/opml/import",
-                           data=data,
-                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
+    response = client.post(
+        "/api/opml/import",
+        data=data,
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
 
     assert response.status_code == 200
     result = response.get_json()
@@ -92,8 +100,9 @@ def test_import_nested_opml(client, mocker):
         assert sub_tech_tab is not None
 
         # Verify affected_tab_ids
-        assert {tech_tab.id, sub_tech_tab.id,
-                result["tab_id"]}.issubset(set(result["affected_tab_ids"]))
+        assert {tech_tab.id, sub_tech_tab.id, result["tab_id"]}.issubset(
+            set(result["affected_tab_ids"])
+        )
 
         # Check feeds
         hn_feed = Feed.query.filter_by(
@@ -140,7 +149,8 @@ def test_opml_import_skips_skipped_folder_types(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -158,7 +168,8 @@ def test_opml_import_skips_skipped_folder_types(client, mocker):
 
         # Assert that the feed in the skipped folder was not created
         skipped_feed = Feed.query.filter_by(
-            url="https://example.com/should-not-import.xml").first()
+            url="https://example.com/should-not-import.xml"
+        ).first()
         assert skipped_feed is None
 
 
@@ -184,7 +195,8 @@ def test_opml_import_skips_invalid_feed_urls(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -235,7 +247,8 @@ def test_opml_import_skips_duplicate_feed_urls(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -248,8 +261,11 @@ def test_opml_import_skips_duplicate_feed_urls(client, mocker):
 
     with app.app_context():
         # Confirm that we still only have one feed per URL overall.
-        feeds_by_url = (Feed.query.with_entities(Feed.url, func.count(
-            Feed.id)).group_by(Feed.url).all())
+        feeds_by_url = (
+            Feed.query.with_entities(Feed.url, func.count(Feed.id))
+            .group_by(Feed.url)
+            .all()
+        )
 
         counts = dict(feeds_by_url)
         assert counts["https://example.com/existing.xml"] == 1
@@ -275,7 +291,8 @@ def test_opml_import_folder_only_no_outlines(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -303,7 +320,8 @@ def test_opml_import_no_outline_elements(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -345,7 +363,8 @@ def test_opml_import_anonymous_folder_with_feeds(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -381,7 +400,8 @@ def test_import_malformed_opml(client):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
+        content_type="multipart/form-data",
+        headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 400

--- a/tests/unit/test_opml_import.py
+++ b/tests/unit/test_opml_import.py
@@ -23,7 +23,7 @@ def test_import(client, mocker):
     # Mock the internal fetch_and_update_feed to avoid actual network calls
     mocker.patch("backend.feed_service.fetch_and_update_feed")
 
-    response = client.post(url, data=data, content_type="multipart/form-data")
+    response = client.post(url, data=data, content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
 
     logger.info("Status Code: %s", response.status_code)
     assert response.status_code == 200
@@ -76,7 +76,7 @@ def test_import_nested_opml(client, mocker):
     data = {"file": (io.BytesIO(opml_content), "nested.opml")}
     response = client.post("/api/opml/import",
                            data=data,
-                           content_type="multipart/form-data")
+                           content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"})
 
     assert response.status_code == 200
     result = response.get_json()
@@ -140,7 +140,7 @@ def test_opml_import_skips_skipped_folder_types(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -184,7 +184,7 @@ def test_opml_import_skips_invalid_feed_urls(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -235,7 +235,7 @@ def test_opml_import_skips_duplicate_feed_urls(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -275,7 +275,7 @@ def test_opml_import_folder_only_no_outlines(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -303,7 +303,7 @@ def test_opml_import_no_outline_elements(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -345,7 +345,7 @@ def test_opml_import_anonymous_folder_with_feeds(client, mocker):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 200
@@ -381,7 +381,7 @@ def test_import_malformed_opml(client):
     response = client.post(
         "/api/opml/import",
         data=data,
-        content_type="multipart/form-data",
+        content_type="multipart/form-data", headers={"X-Requested-With": "XMLHttpRequest"},
     )
 
     assert response.status_code == 400


### PR DESCRIPTION
Added CSRF protection for OPML uploads. Replaced `innerHTML` with `textContent` or `replaceChildren` to improve defense in depth against DOM-based XSS in the frontend.

---
*PR created automatically by Jules for task [10140987421922269302](https://jules.google.com/task/10140987421922269302) started by @sheepdestroyer*

## Summary by Sourcery

Add CSRF protection for OPML import requests and harden frontend DOM updates against XSS while keeping OPML import behavior intact.

Bug Fixes:
- Require an X-Requested-With: XMLHttpRequest header on OPML import requests to mitigate CSRF risk.

Enhancements:
- Ensure frontend OPML import calls include the X-Requested-With header expected by the backend.
- Replace innerHTML-based UI updates with safer DOM APIs (textContent/replaceChildren) in several feed and tab rendering paths to reduce XSS exposure.

Tests:
- Update OPML import unit tests to send the X-Requested-With header so they validate the new CSRF requirement.

Chores:
- Add an empty agent-tools file placeholder to the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering and display consistency of empty-state messages shown in feed views and tab navigation areas by implementing safer DOM manipulation techniques
  * Enhanced the OPML import endpoint with strengthened request validation checks to ensure proper authorization and security

* **Chores**
  * Updated project dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->