### PR TITLE
⚡ Bolt: optimize bulk cache invalidation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,6 +9,11 @@
 ## 2026-02-14 - Optimized Tab.to_dict serialization
 **Learning:** `Tab.to_dict()` triggered a separate SQL query for unread counts, causing N+1 issues when serializing lists of tabs (e.g. in `get_tabs`).
 **Action:** Implemented the same pattern as `Feed.to_dict()`: accept an optional `unread_count` parameter. Updated `get_tabs` to pre-calculate counts in a single query and pass them to `to_dict`.
-## 2026-05-08 - Optimized bulk cache invalidation
-**Learning:** Iterative calls to `cache.set` during bulk operations (like updating multiple feeds) causes N round-trips to the cache server, creating a bottleneck.
-**Action:** Implemented `invalidate_multiple_tabs_cache` using `cache.get_many` and `cache.set_many` to batch fetching and updating of cache version keys, reducing N round-trips to (1)$ operations.
+
+## 2026-04-13 - Add index to Feed.tab_id
+**Learning:** `backend/blueprints/tabs.py` makes frequent lookups via `Feed.query.filter_by(tab_id=tab_id).all()` to resolve feeds for a given tab. In SQLAlchemy models, defining a `db.ForeignKey` doesn't automatically create an index for that column on all databases (e.g. SQLite).
+**Action:** Explicitly add `index=True` to the foreign key `tab_id = db.Column(db.Integer, db.ForeignKey("tabs.id"), nullable=False, index=True)` to prevent full table scans on the `feeds` table during routine feed loading.
+
+## 2026-04-26 - Optimize ORM Object Instantiation for Read-Only API
+**Learning:** Instantiating full SQLAlchemy ORM objects for lists that are immediately serialized to JSON (e.g., using `to_dict()`) introduces significant memory and CPU overhead.
+**Action:** For high-performance, read-only list endpoints like `get_feed_items`, bypass ORM object instantiation by querying specific columns into tuples (e.g., `db.session.execute(select(Model.col1, Model.col2))`) and manually mapping the tuples to dictionaries. This resulted in measurable speedups. Always use local variables for static methods within list comprehensions.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2026-02-14 - Optimized Tab.to_dict serialization
 **Learning:** `Tab.to_dict()` triggered a separate SQL query for unread counts, causing N+1 issues when serializing lists of tabs (e.g. in `get_tabs`).
 **Action:** Implemented the same pattern as `Feed.to_dict()`: accept an optional `unread_count` parameter. Updated `get_tabs` to pre-calculate counts in a single query and pass them to `to_dict`.
+## 2026-05-08 - Optimized bulk cache invalidation
+**Learning:** Iterative calls to `cache.set` during bulk operations (like updating multiple feeds) causes N round-trips to the cache server, creating a bottleneck.
+**Action:** Implemented `invalidate_multiple_tabs_cache` using `cache.get_many` and `cache.set_many` to batch fetching and updating of cache version keys, reducing N round-trips to (1)$ operations.

--- a/backend/blueprints/feeds.py
+++ b/backend/blueprints/feeds.py
@@ -4,7 +4,11 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
-from ..cache_utils import invalidate_tab_feeds_cache, invalidate_tabs_cache, invalidate_multiple_tabs_cache
+from ..cache_utils import (
+    invalidate_multiple_tabs_cache,
+    invalidate_tab_feeds_cache,
+    invalidate_tabs_cache,
+)
 from ..constants import (
     DEFAULT_FEED_ITEMS_LIMIT,
     DEFAULT_PAGINATION_LIMIT,

--- a/backend/blueprints/feeds.py
+++ b/backend/blueprints/feeds.py
@@ -4,7 +4,7 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
-from ..cache_utils import invalidate_tab_feeds_cache, invalidate_tabs_cache
+from ..cache_utils import invalidate_tab_feeds_cache, invalidate_tabs_cache, invalidate_multiple_tabs_cache
 from ..constants import (
     DEFAULT_FEED_ITEMS_LIMIT,
     DEFAULT_PAGINATION_LIMIT,
@@ -311,9 +311,7 @@ def api_update_all_feeds():
             new_items_count,
         )
         if new_items_count > 0 and affected_tab_ids:
-            for tab_id in affected_tab_ids:
-                invalidate_tab_feeds_cache(tab_id, invalidate_tabs=False)
-            invalidate_tabs_cache()
+            invalidate_multiple_tabs_cache(affected_tab_ids)
             logger.info(
                 "Granular cache invalidation completed for affected tabs: %s",
                 affected_tab_ids,

--- a/backend/cache_utils.py
+++ b/backend/cache_utils.py
@@ -119,7 +119,4 @@ def invalidate_multiple_tabs_cache(tab_ids, invalidate_tabs=True):
     if invalidate_tabs:
         invalidate_tabs_cache()
 
-    logger.info(
-        "Bulk invalidated cache for %d tabs.",
-        len(tab_ids_list)
-    )
+    logger.info("Bulk invalidated cache for %d tabs.", len(tab_ids_list))

--- a/backend/cache_utils.py
+++ b/backend/cache_utils.py
@@ -86,3 +86,40 @@ def invalidate_tab_feeds_cache(tab_id, invalidate_tabs=True):
     if invalidate_tabs:
         # Also invalidate the main tabs list because unread counts will have changed.
         invalidate_tabs_cache()
+
+
+def invalidate_multiple_tabs_cache(tab_ids, invalidate_tabs=True):
+    """Optimized bulk cache invalidation for multiple tabs.
+
+    Args:
+        tab_ids (iterable): Iterable of tab IDs to invalidate.
+        invalidate_tabs (bool): If True, also invalidates the main tabs list cache.
+    """
+    tab_ids_list = list(tab_ids)
+    if not tab_ids_list:
+        if invalidate_tabs:
+            invalidate_tabs_cache()
+        return
+
+    # Create keys
+    keys = [get_tab_version_key(t_id) for t_id in tab_ids_list]
+
+    # Fetch current versions in a single round-trip
+    current_versions = cache.get_many(*keys)
+
+    # Calculate new versions and create updates dictionary
+    updates = {}
+    for key, current_v in zip(keys, current_versions):
+        new_v = (current_v if current_v is not None else 1) + 1
+        updates[key] = new_v
+
+    # Set all new versions in a single round-trip
+    cache.set_many(updates)
+
+    if invalidate_tabs:
+        invalidate_tabs_cache()
+
+    logger.info(
+        "Bulk invalidated cache for %d tabs.",
+        len(tab_ids_list)
+    )

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -34,8 +34,8 @@ from defusedxml.common import (
 from sqlalchemy.exc import IntegrityError
 
 from .cache_utils import (
-    invalidate_tab_feeds_cache,
     invalidate_tabs_cache,
+    invalidate_multiple_tabs_cache,
 )
 from .constants import (
     DEFAULT_OPML_IMPORT_TAB_NAME,
@@ -578,9 +578,7 @@ def _invalidate_import_caches(affected_tab_ids_set):
     """Invalidates caches for all tabs affected by the import."""
     if not affected_tab_ids_set:
         return
-    for tab_id in affected_tab_ids_set:
-        invalidate_tab_feeds_cache(tab_id, invalidate_tabs=False)
-    invalidate_tabs_cache()
+    invalidate_multiple_tabs_cache(affected_tab_ids_set)
     logger.info(
         "OPML import: Invalidated caches for tabs: %s.",
         affected_tab_ids_set,

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -34,8 +34,8 @@ from defusedxml.common import (
 from sqlalchemy.exc import IntegrityError
 
 from .cache_utils import (
-    invalidate_tabs_cache,
     invalidate_multiple_tabs_cache,
+    invalidate_tabs_cache,
 )
 from .constants import (
     DEFAULT_OPML_IMPORT_TAB_NAME,
@@ -115,8 +115,9 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(processed_count, total_count,
-                                     last_announced_percent):
+def _calculate_and_announce_progress(
+    processed_count, total_count, last_announced_percent
+):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -128,10 +129,12 @@ def _calculate_and_announce_progress(processed_count, total_count,
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (processed_count == 0 or processed_count >= total_count
-                       or (current_percent != last_announced_percent
-                           and current_percent % 5 == 0)
-                       or processed_count % 20 == 0)
+    should_announce = (
+        processed_count == 0
+        or processed_count >= total_count
+        or (current_percent != last_announced_percent and current_percent % 5 == 0)
+        or processed_count % 20 == 0
+    )
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -239,8 +242,9 @@ def _process_folder_node(
         try:
             nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
                 element_name)
-            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
-                                nested_tab_name))
+            state.stack.append(
+                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
+            )
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -250,7 +254,8 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
+        )
         return
 
     state.skipped_count += 1
@@ -291,11 +296,13 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [(
-        list(reversed(initial_outline_elements)),
-        top_level_tab_id,
-        top_level_tab_name,
-    )]
+    stack = [
+        (
+            list(reversed(initial_outline_elements)),
+            top_level_tab_id,
+            top_level_tab_name,
+        )
+    ]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -313,8 +320,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines,
-                last_announced_percent)
+                processed_outline_count, total_outlines, last_announced_percent
+            )
 
             _process_single_outline_node(
                 outline_element,
@@ -368,13 +375,15 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation).first()
+                name=default_tab_name_for_creation
+            ).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0)
+                    name=default_tab_name_for_creation, order=0
+                )
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -399,7 +408,8 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation).first()
+                        name=default_tab_name_for_creation
+                    ).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -415,10 +425,7 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {
-                                    "error":
-                                    "Failed to create a default tab for import."
-                                },
+                                {"error": "Failed to create a default tab for import."},
                                 500,
                             ),
                         )
@@ -433,10 +440,7 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {
-                                "error":
-                                "Failed to create a default tab for import."
-                            },
+                            {"error": "Failed to create a default tab for import."},
                             500,
                         ),
                     )
@@ -449,16 +453,13 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({
-                "error": "Failed to determine a target tab for import."
-            }, 500),
+            ({"error": "Failed to determine a target tab for import."}, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
-                               affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -489,13 +490,10 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except (SafeET.ParseError, DefusedXmlException) as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s",
-                     e,
-                     exc_info=True)
+        logger.error(
+            "OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
         return None, (
-            {
-                "error": "Malformed OPML file. Please check the file format."
-            },
+            {"error": "Malformed OPML file. Please check the file format."},
             400,
         )
     except OSError as e:
@@ -505,10 +503,7 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {
-                "error":
-                "Could not parse OPML file. Please check the file format."
-            },
+            {"error": "Could not parse OPML file. Please check the file format."},
             400,
         )
 
@@ -531,13 +526,14 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
+                )
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
-                                                                    1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - \
+                1 or (i + 1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -567,9 +563,7 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {
-                "error": "Database error during final feed import step."
-            },
+            {"error": "Database error during final feed import step."},
             500,
         )
 
@@ -633,7 +627,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list)
+        state.newly_added_feeds_list
+    )
     if not success:
         return None, error_resp
 
@@ -667,19 +662,13 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message":
-        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count":
-        imported_final_count,
-        "skipped_count":
-        skipped_final_count,
-        "tab_id":
-        top_level_target_tab_id,
-        "tab_name":
-        top_level_target_tab_name,
-        "affected_tab_ids":
-        list(state.affected_tab_ids_set),
+        "imported_count": imported_final_count,
+        "skipped_count": skipped_final_count,
+        "tab_id": top_level_target_tab_id,
+        "tab_name": top_level_target_tab_name,
+        "affected_tab_ids": list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -802,8 +791,7 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
-                parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -863,8 +851,14 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (ip.is_private or ip.is_loopback or ip.is_link_local
-                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -895,8 +889,9 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
         if self._tunnel_host:
             self._tunnel()
@@ -932,8 +927,9 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -997,15 +993,16 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning("Blocked unsafe redirect to: %s",
-                           _sanitize_for_log(absolute_newurl))
-            raise urllib.error.HTTPError(absolute_newurl, code,
-                                         "Blocked unsafe redirect", headers,
-                                         fp)
+            logger.warning(
+                "Blocked unsafe redirect to: %s", _sanitize_for_log(
+                    absolute_newurl)
+            )
+            raise urllib.error.HTTPError(
+                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
+            )
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers,
-                                           absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1034,8 +1031,9 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception("Error in fetch thread for feed %s",
-                         _sanitize_for_log(feed_url))
+        logger.exception(
+            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
+        )
         return None
 
 
@@ -1114,8 +1112,9 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(http_handler, https_handler,
-                                             redirect_handler)
+        opener = urllib.request.build_opener(
+            http_handler, https_handler, redirect_handler
+        )
 
         req = urllib.request.Request(
             feed_url,
@@ -1170,8 +1169,8 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s",
-                           safe_log_url)
+            logger.warning(
+                "Feed rejected due to security violation: %s", safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1236,9 +1235,12 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (db.session.query(
-        FeedItem.id, FeedItem.guid, FeedItem.link,
-        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
+    items_tuple = (
+        db.session.query(FeedItem.id, FeedItem.guid,
+                         FeedItem.link, FeedItem.title)
+        .filter_by(feed_id=feed_db_obj.id)
+        .all()
+    )
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1265,8 +1267,10 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning("Failed to sort entries for feed %s",
-                       _sanitize_for_log(feed_db_obj.name))
+        logger.warning(
+            "Failed to sort entries for feed %s", _sanitize_for_log(
+                feed_db_obj.name)
+        )
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1315,9 +1319,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-                db_guid,
-                batch_processed_guids,
-                feed_db_obj.name,
+            db_guid,
+            batch_processed_guids,
+            feed_db_obj.name,
         ):
             continue
 
@@ -1331,13 +1335,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            ))
+            )
+        )
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
-                          entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1363,9 +1367,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(
-            FeedItem.id == existing_item_data.id).update(
-                updates, synchronize_session=False)
+        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
+            updates, synchronize_session=False
+        )
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1442,8 +1446,10 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug("Individually added item: %s",
-                         _sanitize_for_log(item.title[:50]))
+            logger.debug(
+                "Individually added item: %s", _sanitize_for_log(
+                    item.title[:50])
+            )
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1495,11 +1501,17 @@ def _enforce_feed_limit(feed_db_obj: Feed):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    stmt = (db.select(FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
-        FeedItem.published_time.desc().nullslast(),
-        FeedItem.fetched_time.desc().nullslast(),
-        FeedItem.id.desc(),
-    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN))
+    stmt = (
+        db.select(FeedItem.id)
+        .filter_by(feed_id=feed_db_obj.id)
+        .order_by(
+            FeedItem.published_time.desc().nullslast(),
+            FeedItem.fetched_time.desc().nullslast(),
+            FeedItem.id.desc(),
+        )
+        .offset(MAX_ITEMS_PER_FEED)
+        .limit(EVICTION_LIMIT_PER_RUN)
+    )
 
     ids_to_evict = list(db.session.scalars(stmt))
 
@@ -1510,9 +1522,12 @@ def _enforce_feed_limit(feed_db_obj: Feed):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i:i + chunk_size]
-        deleted_count += (db.session.query(FeedItem).filter(
-            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
+        chunk = ids_to_evict[i: i + chunk_size]
+        deleted_count += (
+            db.session.query(FeedItem)
+            .filter(FeedItem.id.in_(chunk))
+            .delete(synchronize_session=False)
+        )
 
     if deleted_count > 0:
         logger.info(
@@ -1620,19 +1635,17 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).",
-                total_feeds)
+    logger.info(
+        "Starting update process for %d feeds (Parallelized).", total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
     actual_workers = min(MAX_CONCURRENT_FETCHES,
                          total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(
-            max_workers=actual_workers) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed
-            for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1646,7 +1659,8 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed)
+                    feed_obj, parsed_feed
+                )
                 if success:
                     successful_count += 1
                     total_new_items += new_items


### PR DESCRIPTION
💡 What: Replaced iterative cache invalidations in `feeds.py` and `feed_service.py` with a new `invalidate_multiple_tabs_cache` function in `cache_utils.py` that uses `cache.get_many` and `cache.set_many`.
🎯 Why: Iterative calls to `cache.set` inside loops cause N roundtrips to the cache backend (Redis), creating a performance bottleneck during bulk operations like "Update All Feeds" or OPML imports.
📊 Impact: Reduces N cache round-trips to O(1) bulk operations, significantly speeding up bulk operations.
🔬 Measurement: Verify by executing "Update All Feeds" with multiple feeds in different tabs, checking cache hits, or profiling `api_update_all_feeds`.

---
*PR created automatically by Jules for task [13544357218954574306](https://jules.google.com/task/13544357218954574306) started by @sheepdestroyer*

## Summary by Sourcery

Optimize bulk cache invalidation for tab feeds by introducing a batched invalidation helper and wiring it into bulk feed operations.

New Features:
- Add an invalidate_multiple_tabs_cache helper for bulk invalidation of tab-related cache entries.

Enhancements:
- Use bulk tab cache invalidation in Update All Feeds and OPML import paths to reduce cache backend round-trips and improve performance.

Documentation:
- Extend the Bolt engineering log with notes on the bulk cache invalidation optimization.

Chores:
- Add an empty agent-tools file to the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized bulk cache invalidation during feed updates to reduce server latency and improve performance.
  * Enhanced efficiency of multi-tab feed cache refresh operations.

* **Refactor**
  * Improved feed import workflow code organization.

* **Documentation**
  * Updated changelog with cache optimization details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->