### PR TITLE
🛡️ Sentinel: Fix loose OPML file extension validation

### DIFF
--- a/backend/blueprints/opml.py
+++ b/backend/blueprints/opml.py
@@ -88,7 +88,7 @@ def _validate_opml_file_request():
         return None, (jsonify({"error": "File object is empty"}), 400)
 
     # Basic security: check file extension
-    allowed_extensions = (".opml", ".xml", ".txt")
+    allowed_extensions = (".opml", ".xml")
     _, ext = os.path.splitext(opml_file.filename)
     if ext.lower() not in allowed_extensions:
         err_msg = f"Invalid file type. Allowed: {', '.join(allowed_extensions)}"

--- a/backend/blueprints/opml.py
+++ b/backend/blueprints/opml.py
@@ -38,8 +38,8 @@ def _generate_opml_string(tabs=None):
 
     if tabs is None:
         # Eager load feeds to avoid N+1 queries
-        tabs = Tab.query.options(selectinload(Tab.feeds)).order_by(
-            Tab.order).all()
+        tabs = Tab.query.options(selectinload(
+            Tab.feeds)).order_by(Tab.order).all()
 
     for tab in tabs:
         # Skip tabs with no feeds
@@ -65,10 +65,9 @@ def _generate_opml_string(tabs=None):
 
     # Use unsafe_tostring because we are strictly generating XML, not parsing it.
     # We encode to utf-8 and decode to unicode to ensure a correct XML declaration.
-    opml_string = unsafe_tostring(opml_element,
-                                  encoding="utf-8",
-                                  method="xml",
-                                  xml_declaration=True).decode("utf-8")
+    opml_string = unsafe_tostring(
+        opml_element, encoding="utf-8", method="xml", xml_declaration=True
+    ).decode("utf-8")
 
     feed_count = sum(len(tab.feeds) for tab in tabs)
     tab_count = sum(1 for tab in tabs if tab.feeds)
@@ -82,8 +81,7 @@ def _validate_opml_file_request():
         return None, (jsonify({"error": "No file part in the request"}), 400)
     opml_file = request.files["file"]
     if opml_file.filename == "":
-        return None, (jsonify({"error":
-                               "No file selected for uploading"}), 400)
+        return None, (jsonify({"error": "No file selected for uploading"}), 400)
     if not opml_file:
         return None, (jsonify({"error": "File object is empty"}), 400)
 
@@ -114,8 +112,8 @@ def import_opml():
     requested_tab_id_str = request.form.get("tab_id")
 
     # Call the service function
-    result, error_info = import_opml_service(opml_file.stream,
-                                             requested_tab_id_str)
+    result, error_info = import_opml_service(
+        opml_file.stream, requested_tab_id_str)
 
     if error_info:
         error_json, status_code = error_info
@@ -143,7 +141,8 @@ def export_opml():
 
     response = Response(opml_string, mimetype="application/xml")
     response.headers["Content-Disposition"] = (
-        'attachment; filename="sheepvibes_feeds.opml"')
+        'attachment; filename="sheepvibes_feeds.opml"'
+    )
 
     logger.info(
         "Successfully generated OPML export for %d feeds across %d tabs.",
@@ -178,12 +177,12 @@ def _get_autosave_directory():
                 abs_db_path = os.path.abspath(db_path)
                 data_dir = os.path.dirname(abs_db_path)
                 logger.debug(
-                    "Resolved autosave directory from SQLite path: %s",
-                    data_dir)
+                    "Resolved autosave directory from SQLite path: %s", data_dir
+                )
             except Exception:
                 logger.warning(
-                    "Could not resolve absolute path for SQLite DB: %s",
-                    db_path)
+                    "Could not resolve absolute path for SQLite DB: %s", db_path
+                )
 
     if not data_dir:
         # 3. Fall back to PROJECT_ROOT/data
@@ -193,7 +192,8 @@ def _get_autosave_directory():
 
     if not data_dir:
         logger.warning(
-            "Could not determine autosave directory. Skipping OPML autosave.")
+            "Could not determine autosave directory. Skipping OPML autosave."
+        )
         return None
 
     try:
@@ -234,8 +234,8 @@ def _write_atomically_with_lock(autosave_path, opml_string):
             try:
                 os.remove(temp_path)
             except OSError as e:
-                logger.warning("Failed to remove temporary file %s: %s",
-                               temp_path, e)
+                logger.warning(
+                    "Failed to remove temporary file %s: %s", temp_path, e)
     return False
 
 

--- a/tests/unit/test_opml_import.py
+++ b/tests/unit/test_opml_import.py
@@ -388,3 +388,27 @@ def test_import_malformed_opml(client):
 
     payload = response.get_json()
     assert "Malformed OPML file" in payload.get("error", "")
+
+
+def test_import_opml_txt_file_rejected(client):
+    """Test that .txt files are rejected during OPML import."""
+    # Create a simple text file content
+    txt_content = b"This is a plain text file, not an OPML file"
+    
+    data = {
+        "file": (io.BytesIO(txt_content), "test.txt"),
+    }
+
+    response = client.post(
+        "/api/opml/import",
+        data=data,
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    
+    payload = response.get_json()
+    assert "Invalid file type" in payload.get("error", "")
+    assert ".opml" in payload.get("error", "")
+    assert ".xml" in payload.get("error", "")
+    assert ".txt" not in payload.get("error", "")  # Should not mention .txt as allowed

--- a/tests/unit/test_opml_import.py
+++ b/tests/unit/test_opml_import.py
@@ -367,6 +367,27 @@ def test_opml_import_anonymous_folder_with_feeds(client, mocker):
         assert feed.tab_id == result["tab_id"]
 
 
+def test_import_opml_txt_file_rejected(client):
+    """Test that .txt files are rejected for OPML import."""
+    opml_content = b'<opml version="1.0"><body><outline text="Test" xmlUrl="http://example.com/feed" /></body></opml>'
+    opml_file = io.BytesIO(opml_content)
+
+    data = {"file": (opml_file, "test_feeds.txt")}
+
+    response = client.post(
+        "/api/opml/import",
+        data=data,
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert "Invalid file type" in payload.get("error", "")
+    assert ".opml" in payload.get("error", "")
+    assert ".xml" in payload.get("error", "")
+    assert ".txt" not in payload.get("error", "")
+
+
 def test_import_malformed_opml(client):
     """Test importing a malformed OPML yields a parse error response."""
     malformed_opml = b"""<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/unit/test_opml_import.py
+++ b/tests/unit/test_opml_import.py
@@ -74,9 +74,9 @@ def test_import_nested_opml(client, mocker):
                  return_value=True)
 
     data = {"file": (io.BytesIO(opml_content), "nested.opml")}
-    response = client.post("/api/opml/import",
-                           data=data,
-                           content_type="multipart/form-data")
+    response = client.post(
+        "/api/opml/import", data=data, content_type="multipart/form-data"
+    )
 
     assert response.status_code == 200
     result = response.get_json()
@@ -92,8 +92,9 @@ def test_import_nested_opml(client, mocker):
         assert sub_tech_tab is not None
 
         # Verify affected_tab_ids
-        assert {tech_tab.id, sub_tech_tab.id,
-                result["tab_id"]}.issubset(set(result["affected_tab_ids"]))
+        assert {tech_tab.id, sub_tech_tab.id, result["tab_id"]}.issubset(
+            set(result["affected_tab_ids"])
+        )
 
         # Check feeds
         hn_feed = Feed.query.filter_by(
@@ -158,7 +159,8 @@ def test_opml_import_skips_skipped_folder_types(client, mocker):
 
         # Assert that the feed in the skipped folder was not created
         skipped_feed = Feed.query.filter_by(
-            url="https://example.com/should-not-import.xml").first()
+            url="https://example.com/should-not-import.xml"
+        ).first()
         assert skipped_feed is None
 
 
@@ -248,8 +250,11 @@ def test_opml_import_skips_duplicate_feed_urls(client, mocker):
 
     with app.app_context():
         # Confirm that we still only have one feed per URL overall.
-        feeds_by_url = (Feed.query.with_entities(Feed.url, func.count(
-            Feed.id)).group_by(Feed.url).all())
+        feeds_by_url = (
+            Feed.query.with_entities(Feed.url, func.count(Feed.id))
+            .group_by(Feed.url)
+            .all()
+        )
 
         counts = dict(feeds_by_url)
         assert counts["https://example.com/existing.xml"] == 1
@@ -394,7 +399,7 @@ def test_import_opml_txt_file_rejected(client):
     """Test that .txt files are rejected during OPML import."""
     # Create a simple text file content
     txt_content = b"This is a plain text file, not an OPML file"
-    
+
     data = {
         "file": (io.BytesIO(txt_content), "test.txt"),
     }
@@ -406,9 +411,10 @@ def test_import_opml_txt_file_rejected(client):
     )
 
     assert response.status_code == 400
-    
+
     payload = response.get_json()
     assert "Invalid file type" in payload.get("error", "")
     assert ".opml" in payload.get("error", "")
     assert ".xml" in payload.get("error", "")
-    assert ".txt" not in payload.get("error", "")  # Should not mention .txt as allowed
+    # Should not mention .txt as allowed
+    assert ".txt" not in payload.get("error", "")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The OPML import endpoint loosely permitted `.txt` extensions, exposing the application to potentially unintended file types being processed. 
🎯 Impact: This could be leveraged to bypass intended XML processing restrictions or clutter the system with unexpected file formats, increasing the attack surface.
🔧 Fix: Removed `.txt` from `allowed_extensions` in `backend/blueprints/opml.py` so that only `.opml` and `.xml` are accepted. Added a regression test to verify this restriction.
✅ Verification: Ensure the test suite passes (`pytest tests/unit/test_opml_import.py -k test_import_opml_txt_file_rejected`) and the `flake8` linters show no regression.

---
*PR created automatically by Jules for task [5938323694601439817](https://jules.google.com/task/5938323694601439817) started by @sheepdestroyer*

## Summary by Sourcery

Chores:
- Introduce an initial agent-tools file to prepare for future tooling or automation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OPML upload validation now accepts only .opml and .xml files (uploads with .txt are rejected).

* **Tests**
  * Added unit test coverage to verify OPML import rejects .txt uploads and enforces allowed formats.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/SheepVibes/pull/454)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->