### PR TITLE
🧪 Add tests for _is_safe_ip in feed_service

### DIFF
--- a/tests/unit/test_safe_ip.py
+++ b/tests/unit/test_safe_ip.py
@@ -1,12 +1,8 @@
 import ipaddress
-
 import pytest
-
 from backend.feed_service import _is_safe_ip
 
-
 class TestIsSafeIp:
-
     @pytest.mark.parametrize(
         "ip_str, expected",
         [
@@ -15,25 +11,28 @@ class TestIsSafeIp:
             ("1.1.1.1", True),  # Cloudflare DNS
             ("142.250.190.46", True),  # Google
             ("104.244.42.1", True),  # Twitter
+
             # --- IPv4 Invalid IPs (Unsafe) ---
             ("127.0.0.1", False),  # Loopback
-            ("10.0.0.1", False),  # Private (Class A)
-            ("172.16.0.1", False),  # Private (Class B)
-            ("192.168.1.1", False),  # Private (Class C)
-            ("169.254.0.1", False),  # Link-local
-            ("224.0.0.1", False),  # Multicast
-            ("0.0.0.0", False),  # Unspecified
-            ("240.0.0.1", False),  # Reserved
+            ("10.0.0.1", False),   # Private (Class A)
+            ("172.16.0.1", False), # Private (Class B)
+            ("192.168.1.1", False), # Private (Class C)
+            ("169.254.0.1", False), # Link-local
+            ("224.0.0.1", False),   # Multicast
+            ("0.0.0.0", False),     # Unspecified
+            ("240.0.0.1", False),   # Reserved
+
             # --- IPv6 Valid Public IPs (Safe) ---
-            ("2001:4860:4860::8888", True),  # Google DNS
-            ("2606:4700:4700::1111", True),  # Cloudflare DNS
+            ("2001:4860:4860::8888", True), # Google DNS
+            ("2606:4700:4700::1111", True), # Cloudflare DNS
+
             # --- IPv6 Invalid IPs (Unsafe) ---
-            ("::1", False),  # Loopback
-            ("fc00::1", False),  # Unique Local Address (Private)
-            ("fd00::1", False),  # Unique Local Address (Private)
-            ("fe80::1", False),  # Link-local
-            ("ff02::1", False),  # Multicast
-            ("::", False),  # Unspecified
+            ("::1", False),                 # Loopback
+            ("fc00::1", False),             # Unique Local Address (Private)
+            ("fd00::1", False),             # Unique Local Address (Private)
+            ("fe80::1", False),             # Link-local
+            ("ff02::1", False),             # Multicast
+            ("::", False),                  # Unspecified
         ],
     )
     def test_is_safe_ip(self, ip_str, expected):

--- a/tests/unit/test_safe_ip.py
+++ b/tests/unit/test_safe_ip.py
@@ -1,0 +1,41 @@
+import ipaddress
+import pytest
+from backend.feed_service import _is_safe_ip
+
+class TestIsSafeIp:
+    @pytest.mark.parametrize(
+        "ip_str, expected",
+        [
+            # --- IPv4 Valid Public IPs (Safe) ---
+            ("8.8.8.8", True),  # Google DNS
+            ("1.1.1.1", True),  # Cloudflare DNS
+            ("142.250.190.46", True),  # Google
+            ("104.244.42.1", True),  # Twitter
+
+            # --- IPv4 Invalid IPs (Unsafe) ---
+            ("127.0.0.1", False),  # Loopback
+            ("10.0.0.1", False),   # Private (Class A)
+            ("172.16.0.1", False), # Private (Class B)
+            ("192.168.1.1", False), # Private (Class C)
+            ("169.254.0.1", False), # Link-local
+            ("224.0.0.1", False),   # Multicast
+            ("0.0.0.0", False),     # Unspecified
+            ("240.0.0.1", False),   # Reserved
+
+            # --- IPv6 Valid Public IPs (Safe) ---
+            ("2001:4860:4860::8888", True), # Google DNS
+            ("2606:4700:4700::1111", True), # Cloudflare DNS
+
+            # --- IPv6 Invalid IPs (Unsafe) ---
+            ("::1", False),                 # Loopback
+            ("fc00::1", False),             # Unique Local Address (Private)
+            ("fd00::1", False),             # Unique Local Address (Private)
+            ("fe80::1", False),             # Link-local
+            ("ff02::1", False),             # Multicast
+            ("::", False),                  # Unspecified
+        ],
+    )
+    def test_is_safe_ip(self, ip_str, expected):
+        """Test _is_safe_ip correctly identifies safe/unsafe IPs for both IPv4 and IPv6."""
+        ip_obj = ipaddress.ip_address(ip_str)
+        assert _is_safe_ip(ip_obj) == expected

--- a/tests/unit/test_safe_ip.py
+++ b/tests/unit/test_safe_ip.py
@@ -1,8 +1,12 @@
 import ipaddress
+
 import pytest
+
 from backend.feed_service import _is_safe_ip
 
+
 class TestIsSafeIp:
+
     @pytest.mark.parametrize(
         "ip_str, expected",
         [
@@ -11,28 +15,25 @@ class TestIsSafeIp:
             ("1.1.1.1", True),  # Cloudflare DNS
             ("142.250.190.46", True),  # Google
             ("104.244.42.1", True),  # Twitter
-
             # --- IPv4 Invalid IPs (Unsafe) ---
             ("127.0.0.1", False),  # Loopback
-            ("10.0.0.1", False),   # Private (Class A)
-            ("172.16.0.1", False), # Private (Class B)
-            ("192.168.1.1", False), # Private (Class C)
-            ("169.254.0.1", False), # Link-local
-            ("224.0.0.1", False),   # Multicast
-            ("0.0.0.0", False),     # Unspecified
-            ("240.0.0.1", False),   # Reserved
-
+            ("10.0.0.1", False),  # Private (Class A)
+            ("172.16.0.1", False),  # Private (Class B)
+            ("192.168.1.1", False),  # Private (Class C)
+            ("169.254.0.1", False),  # Link-local
+            ("224.0.0.1", False),  # Multicast
+            ("0.0.0.0", False),  # Unspecified
+            ("240.0.0.1", False),  # Reserved
             # --- IPv6 Valid Public IPs (Safe) ---
-            ("2001:4860:4860::8888", True), # Google DNS
-            ("2606:4700:4700::1111", True), # Cloudflare DNS
-
+            ("2001:4860:4860::8888", True),  # Google DNS
+            ("2606:4700:4700::1111", True),  # Cloudflare DNS
             # --- IPv6 Invalid IPs (Unsafe) ---
-            ("::1", False),                 # Loopback
-            ("fc00::1", False),             # Unique Local Address (Private)
-            ("fd00::1", False),             # Unique Local Address (Private)
-            ("fe80::1", False),             # Link-local
-            ("ff02::1", False),             # Multicast
-            ("::", False),                  # Unspecified
+            ("::1", False),  # Loopback
+            ("fc00::1", False),  # Unique Local Address (Private)
+            ("fd00::1", False),  # Unique Local Address (Private)
+            ("fe80::1", False),  # Link-local
+            ("ff02::1", False),  # Multicast
+            ("::", False),  # Unspecified
         ],
     )
     def test_is_safe_ip(self, ip_str, expected):


### PR DESCRIPTION
🎯 **What:** Adds missing test coverage for the `_is_safe_ip` function in `backend/feed_service.py` to ensure proper behavior in identifying safe/unsafe IPv4 and IPv6 addresses.
📊 **Coverage:** Tests various scenarios including happy paths (public IPs) and edge cases/error paths (private, loopback, link-local, multicast, etc.) using pytest parametrization.
✨ **Result:** Improved test coverage and regression prevention for critical IP validation functionality.

---
*PR created automatically by Jules for task [16934706835428533713](https://jules.google.com/task/16934706835428533713) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Introduce parametrized tests verifying _is_safe_ip behavior for various IPv4 and IPv6 public, private, loopback, link-local, multicast, reserved, and unspecified addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated agent-tools subproject dependency

* **Tests**
  * Added comprehensive unit tests for IP address validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/SheepVibes/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->