### PR TITLE
🧹 Fix unused import in feed_service.py

### DIFF
--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -18,9 +18,9 @@ import urllib.request
 from dataclasses import dataclass
 from datetime import timezone  # Specifically import timezone
 from urllib.parse import urljoin, urlparse
-from xml.etree.ElementTree import Element  # skipcq: BAN-B405
 from xml.sax import SAXParseException
 from xml.sax.handler import ContentHandler
+from xml.etree.ElementTree import Element  # skipcq: BAN-B405
 
 import defusedxml.ElementTree as SafeET
 import defusedxml.sax
@@ -52,6 +52,7 @@ from .sse import announcer
 
 # Set up logger for this module
 logger = logging.getLogger(__name__)
+
 
 # Type alias for the stack items: (list of XML elements, current_tab_id, current_tab_name)
 OpmlStackItem = tuple[list[Element], int, str]
@@ -110,9 +111,8 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(
-    processed_count, total_count, last_announced_percent
-):
+def _calculate_and_announce_progress(processed_count, total_count,
+                                     last_announced_percent):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -124,12 +124,10 @@ def _calculate_and_announce_progress(
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (
-        processed_count == 0
-        or processed_count >= total_count
-        or (current_percent != last_announced_percent and current_percent % 5 == 0)
-        or processed_count % 20 == 0
-    )
+    should_announce = (processed_count == 0 or processed_count >= total_count
+                       or (current_percent != last_announced_percent
+                           and current_percent % 5 == 0)
+                       or processed_count % 20 == 0)
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -235,10 +233,10 @@ def _process_folder_node(
 
     if element_name and child_outlines:
         try:
-            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(element_name)
-            state.stack.append(
-                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
-            )
+            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
+                element_name)
+            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
+                                nested_tab_name))
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -248,8 +246,7 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
-        )
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
         return
 
     state.skipped_count += 1
@@ -290,13 +287,11 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [
-        (
-            list(reversed(initial_outline_elements)),
-            top_level_tab_id,
-            top_level_tab_name,
-        )
-    ]
+    stack = [(
+        list(reversed(initial_outline_elements)),
+        top_level_tab_id,
+        top_level_tab_name,
+    )]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -314,8 +309,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines, last_announced_percent
-            )
+                processed_outline_count, total_outlines,
+                last_announced_percent)
 
             _process_single_outline_node(
                 outline_element,
@@ -369,15 +364,13 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation
-            ).first()
+                name=default_tab_name_for_creation).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0
-                )
+                    name=default_tab_name_for_creation, order=0)
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -402,8 +395,7 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation
-                    ).first()
+                        name=default_tab_name_for_creation).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -419,7 +411,10 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {"error": "Failed to create a default tab for import."},
+                                {
+                                    "error":
+                                    "Failed to create a default tab for import."
+                                },
                                 500,
                             ),
                         )
@@ -434,7 +429,10 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {"error": "Failed to create a default tab for import."},
+                            {
+                                "error":
+                                "Failed to create a default tab for import."
+                            },
                             500,
                         ),
                     )
@@ -447,13 +445,16 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({"error": "Failed to determine a target tab for import."}, 500),
+            ({
+                "error": "Failed to determine a target tab for import."
+            }, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
+                               affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -484,9 +485,13 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except SafeET.ParseError as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
+        logger.error("OPML import failed: Malformed XML. Error: %s",
+                     e,
+                     exc_info=True)
         return None, (
-            {"error": "Malformed OPML file. Please check the file format."},
+            {
+                "error": "Malformed OPML file. Please check the file format."
+            },
             400,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -496,7 +501,10 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {"error": "Could not parse OPML file. Please check the file format."},
+            {
+                "error":
+                "Could not parse OPML file. Please check the file format."
+            },
             400,
         )
 
@@ -519,13 +527,13 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
-                )
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i + 1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
+                                                                    1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -555,7 +563,9 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {"error": "Database error during final feed import step."},
+            {
+                "error": "Database error during final feed import step."
+            },
             500,
         )
 
@@ -621,8 +631,7 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list
-    )
+        state.newly_added_feeds_list)
     if not success:
         return None, error_resp
 
@@ -638,7 +647,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     )
 
     if not opml_body.findall("outline") and not state.newly_added_feeds_list:
-        logger.info("OPML import: No <outline> elements found in the OPML body.")
+        logger.info(
+            "OPML import: No <outline> elements found in the OPML body.")
         result = {
             "message": "No feed entries or folders found in the OPML file.",
             "imported_count": 0,
@@ -655,13 +665,19 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message":
+        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count": imported_final_count,
-        "skipped_count": skipped_final_count,
-        "tab_id": top_level_target_tab_id,
-        "tab_name": top_level_target_tab_name,
-        "affected_tab_ids": list(state.affected_tab_ids_set),
+        "imported_count":
+        imported_final_count,
+        "skipped_count":
+        skipped_final_count,
+        "tab_id":
+        top_level_target_tab_id,
+        "tab_name":
+        top_level_target_tab_name,
+        "affected_tab_ids":
+        list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -735,7 +751,8 @@ def _validate_xml_safety(content):
             forbid_external=True,
         )
     except (DTDForbidden, EntitiesForbidden, ExternalReferenceForbidden) as e:
-        logger.error("XML Security Violation detected: %s", _sanitize_for_log(str(e)))
+        logger.error("XML Security Violation detected: %s",
+                     _sanitize_for_log(str(e)))
         return False
     except (SAXParseException, UnicodeError) as e:
         # SECURITY HARDENING: Fail closed on malformed XML.
@@ -783,7 +800,8 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
+                parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -843,14 +861,8 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_reserved
-        or ip.is_multicast
-        or ip.is_unspecified
-    )
+    return not (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -881,9 +893,8 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection(
-            (self.safe_ip, self.port), self.timeout, self.source_address
-        )
+        self.sock = socket.create_connection((self.safe_ip, self.port),
+                                             self.timeout, self.source_address)
 
         if self._tunnel_host:
             self._tunnel()
@@ -919,9 +930,8 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection(
-            (self.safe_ip, self.port), self.timeout, self.source_address
-        )
+        self.sock = socket.create_connection((self.safe_ip, self.port),
+                                             self.timeout, self.source_address)
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -985,15 +995,15 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning(
-                "Blocked unsafe redirect to: %s", _sanitize_for_log(absolute_newurl)
-            )
-            raise urllib.error.HTTPError(
-                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
-            )
+            logger.warning("Blocked unsafe redirect to: %s",
+                           _sanitize_for_log(absolute_newurl))
+            raise urllib.error.HTTPError(absolute_newurl, code,
+                                         "Blocked unsafe redirect", headers,
+                                         fp)
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers,
+                                           absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1022,9 +1032,8 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception(
-            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
-        )
+        logger.exception("Error in fetch thread for feed %s",
+                         _sanitize_for_log(feed_url))
         return None
 
 
@@ -1103,9 +1112,8 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(
-            http_handler, https_handler, redirect_handler
-        )
+        opener = urllib.request.build_opener(http_handler, https_handler,
+                                             redirect_handler)
 
         req = urllib.request.Request(
             feed_url,
@@ -1160,7 +1168,8 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s", safe_log_url)
+            logger.warning("Feed rejected due to security violation: %s",
+                           safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1168,7 +1177,8 @@ def fetch_feed(feed_url):
         if parsed_feed.bozo:
             # Check for bozo_exception and sanitize it (it can contain malicious input)
             bozo_exc = parsed_feed.get("bozo_exception")
-            safe_exc_msg = _sanitize_for_log(str(bozo_exc)) if bozo_exc else "Unknown"
+            safe_exc_msg = _sanitize_for_log(
+                str(bozo_exc)) if bozo_exc else "Unknown"
             logger.warning("Feed parsing warning: %s", safe_exc_msg)
 
         return parsed_feed
@@ -1224,11 +1234,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (
-        db.session.query(FeedItem.id, FeedItem.guid, FeedItem.link, FeedItem.title)
-        .filter_by(feed_id=feed_db_obj.id)
-        .all()
-    )
+    items_tuple = (db.session.query(
+        FeedItem.id, FeedItem.guid, FeedItem.link,
+        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1255,9 +1263,8 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning(
-            "Failed to sort entries for feed %s", _sanitize_for_log(feed_db_obj.name)
-        )
+        logger.warning("Failed to sort entries for feed %s",
+                       _sanitize_for_log(feed_db_obj.name))
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1306,9 +1313,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-            db_guid,
-            batch_processed_guids,
-            feed_db_obj.name,
+                db_guid,
+                batch_processed_guids,
+                feed_db_obj.name,
         ):
             continue
 
@@ -1322,13 +1329,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            )
-        )
+            ))
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
+                          entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1354,9 +1361,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_li
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
-            updates, synchronize_session=False
-        )
+        db.session.query(FeedItem).filter(
+            FeedItem.id == existing_item_data.id).update(
+                updates, synchronize_session=False)
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1437,9 +1444,8 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug(
-                "Individually added item: %s", _sanitize_for_log(item.title[:50])
-            )
+            logger.debug("Individually added item: %s",
+                         _sanitize_for_log(item.title[:50]))
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1491,18 +1497,12 @@ def _enforce_feed_limit(feed_db_obj):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    ids_to_evict_rows = (
-        db.session.query(FeedItem.id)
-        .filter_by(feed_id=feed_db_obj.id)
-        .order_by(
+    ids_to_evict_rows = (db.session.query(
+        FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
             FeedItem.published_time.desc().nullslast(),
             FeedItem.fetched_time.desc().nullslast(),
             FeedItem.id.desc(),
-        )
-        .offset(MAX_ITEMS_PER_FEED)
-        .limit(EVICTION_LIMIT_PER_RUN)
-        .all()
-    )
+    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN).all())
 
     if not ids_to_evict_rows:
         return
@@ -1513,12 +1513,9 @@ def _enforce_feed_limit(feed_db_obj):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i : i + chunk_size]
-        deleted_count += (
-            db.session.query(FeedItem)
-            .filter(FeedItem.id.in_(chunk))
-            .delete(synchronize_session=False)
-        )
+        chunk = ids_to_evict[i:i + chunk_size]
+        deleted_count += (db.session.query(FeedItem).filter(
+            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
 
     if deleted_count > 0:
         logger.info(
@@ -1626,15 +1623,19 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).", total_feeds)
+    logger.info("Starting update process for %d feeds (Parallelized).",
+                total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
-    actual_workers = min(MAX_CONCURRENT_FETCHES, total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
+    actual_workers = min(MAX_CONCURRENT_FETCHES,
+                         total_feeds) if all_feeds else 1
+    with concurrent.futures.ThreadPoolExecutor(
+            max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed
+            for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1648,8 +1649,7 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed
-                )
+                    feed_obj, parsed_feed)
                 if success:
                     successful_count += 1
                     total_new_items += new_items

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -18,9 +18,9 @@ import urllib.request
 from dataclasses import dataclass
 from datetime import timezone  # Specifically import timezone
 from urllib.parse import urljoin, urlparse
+from xml.etree.ElementTree import Element  # skipcq: BAN-B405
 from xml.sax import SAXParseException
 from xml.sax.handler import ContentHandler
-from xml.etree.ElementTree import Element  # skipcq: BAN-B405
 
 import defusedxml.ElementTree as SafeET
 import defusedxml.sax
@@ -52,7 +52,6 @@ from .sse import announcer
 
 # Set up logger for this module
 logger = logging.getLogger(__name__)
-
 
 # Type alias for the stack items: (list of XML elements, current_tab_id, current_tab_name)
 OpmlStackItem = tuple[list[Element], int, str]
@@ -111,8 +110,9 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(processed_count, total_count,
-                                     last_announced_percent):
+def _calculate_and_announce_progress(
+    processed_count, total_count, last_announced_percent
+):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -124,10 +124,12 @@ def _calculate_and_announce_progress(processed_count, total_count,
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (processed_count == 0 or processed_count >= total_count
-                       or (current_percent != last_announced_percent
-                           and current_percent % 5 == 0)
-                       or processed_count % 20 == 0)
+    should_announce = (
+        processed_count == 0
+        or processed_count >= total_count
+        or (current_percent != last_announced_percent and current_percent % 5 == 0)
+        or processed_count % 20 == 0
+    )
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -233,10 +235,10 @@ def _process_folder_node(
 
     if element_name and child_outlines:
         try:
-            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
-                element_name)
-            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
-                                nested_tab_name))
+            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(element_name)
+            state.stack.append(
+                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
+            )
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -246,7 +248,8 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
+        )
         return
 
     state.skipped_count += 1
@@ -287,11 +290,13 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [(
-        list(reversed(initial_outline_elements)),
-        top_level_tab_id,
-        top_level_tab_name,
-    )]
+    stack = [
+        (
+            list(reversed(initial_outline_elements)),
+            top_level_tab_id,
+            top_level_tab_name,
+        )
+    ]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -309,8 +314,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines,
-                last_announced_percent)
+                processed_outline_count, total_outlines, last_announced_percent
+            )
 
             _process_single_outline_node(
                 outline_element,
@@ -364,13 +369,15 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation).first()
+                name=default_tab_name_for_creation
+            ).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0)
+                    name=default_tab_name_for_creation, order=0
+                )
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -395,7 +402,8 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation).first()
+                        name=default_tab_name_for_creation
+                    ).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -411,10 +419,7 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {
-                                    "error":
-                                    "Failed to create a default tab for import."
-                                },
+                                {"error": "Failed to create a default tab for import."},
                                 500,
                             ),
                         )
@@ -429,10 +434,7 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {
-                                "error":
-                                "Failed to create a default tab for import."
-                            },
+                            {"error": "Failed to create a default tab for import."},
                             500,
                         ),
                     )
@@ -445,16 +447,13 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({
-                "error": "Failed to determine a target tab for import."
-            }, 500),
+            ({"error": "Failed to determine a target tab for import."}, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
-                               affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -485,13 +484,9 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except SafeET.ParseError as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s",
-                     e,
-                     exc_info=True)
+        logger.error("OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
         return None, (
-            {
-                "error": "Malformed OPML file. Please check the file format."
-            },
+            {"error": "Malformed OPML file. Please check the file format."},
             400,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -501,10 +496,7 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {
-                "error":
-                "Could not parse OPML file. Please check the file format."
-            },
+            {"error": "Could not parse OPML file. Please check the file format."},
             400,
         )
 
@@ -527,13 +519,13 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
+                )
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
-                                                                    1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - 1 or (i + 1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -563,9 +555,7 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {
-                "error": "Database error during final feed import step."
-            },
+            {"error": "Database error during final feed import step."},
             500,
         )
 
@@ -631,7 +621,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list)
+        state.newly_added_feeds_list
+    )
     if not success:
         return None, error_resp
 
@@ -647,8 +638,7 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     )
 
     if not opml_body.findall("outline") and not state.newly_added_feeds_list:
-        logger.info(
-            "OPML import: No <outline> elements found in the OPML body.")
+        logger.info("OPML import: No <outline> elements found in the OPML body.")
         result = {
             "message": "No feed entries or folders found in the OPML file.",
             "imported_count": 0,
@@ -665,19 +655,13 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message":
-        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count":
-        imported_final_count,
-        "skipped_count":
-        skipped_final_count,
-        "tab_id":
-        top_level_target_tab_id,
-        "tab_name":
-        top_level_target_tab_name,
-        "affected_tab_ids":
-        list(state.affected_tab_ids_set),
+        "imported_count": imported_final_count,
+        "skipped_count": skipped_final_count,
+        "tab_id": top_level_target_tab_id,
+        "tab_name": top_level_target_tab_name,
+        "affected_tab_ids": list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -751,8 +735,7 @@ def _validate_xml_safety(content):
             forbid_external=True,
         )
     except (DTDForbidden, EntitiesForbidden, ExternalReferenceForbidden) as e:
-        logger.error("XML Security Violation detected: %s",
-                     _sanitize_for_log(str(e)))
+        logger.error("XML Security Violation detected: %s", _sanitize_for_log(str(e)))
         return False
     except (SAXParseException, UnicodeError) as e:
         # SECURITY HARDENING: Fail closed on malformed XML.
@@ -800,8 +783,7 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
-                parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -861,8 +843,14 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (ip.is_private or ip.is_loopback or ip.is_link_local
-                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -893,8 +881,9 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
         if self._tunnel_host:
             self._tunnel()
@@ -930,8 +919,9 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -995,15 +985,15 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning("Blocked unsafe redirect to: %s",
-                           _sanitize_for_log(absolute_newurl))
-            raise urllib.error.HTTPError(absolute_newurl, code,
-                                         "Blocked unsafe redirect", headers,
-                                         fp)
+            logger.warning(
+                "Blocked unsafe redirect to: %s", _sanitize_for_log(absolute_newurl)
+            )
+            raise urllib.error.HTTPError(
+                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
+            )
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers,
-                                           absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1032,8 +1022,9 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception("Error in fetch thread for feed %s",
-                         _sanitize_for_log(feed_url))
+        logger.exception(
+            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
+        )
         return None
 
 
@@ -1112,8 +1103,9 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(http_handler, https_handler,
-                                             redirect_handler)
+        opener = urllib.request.build_opener(
+            http_handler, https_handler, redirect_handler
+        )
 
         req = urllib.request.Request(
             feed_url,
@@ -1168,8 +1160,7 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s",
-                           safe_log_url)
+            logger.warning("Feed rejected due to security violation: %s", safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1177,8 +1168,7 @@ def fetch_feed(feed_url):
         if parsed_feed.bozo:
             # Check for bozo_exception and sanitize it (it can contain malicious input)
             bozo_exc = parsed_feed.get("bozo_exception")
-            safe_exc_msg = _sanitize_for_log(
-                str(bozo_exc)) if bozo_exc else "Unknown"
+            safe_exc_msg = _sanitize_for_log(str(bozo_exc)) if bozo_exc else "Unknown"
             logger.warning("Feed parsing warning: %s", safe_exc_msg)
 
         return parsed_feed
@@ -1234,9 +1224,11 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (db.session.query(
-        FeedItem.id, FeedItem.guid, FeedItem.link,
-        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
+    items_tuple = (
+        db.session.query(FeedItem.id, FeedItem.guid, FeedItem.link, FeedItem.title)
+        .filter_by(feed_id=feed_db_obj.id)
+        .all()
+    )
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1263,8 +1255,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning("Failed to sort entries for feed %s",
-                       _sanitize_for_log(feed_db_obj.name))
+        logger.warning(
+            "Failed to sort entries for feed %s", _sanitize_for_log(feed_db_obj.name)
+        )
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1313,9 +1306,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-                db_guid,
-                batch_processed_guids,
-                feed_db_obj.name,
+            db_guid,
+            batch_processed_guids,
+            feed_db_obj.name,
         ):
             continue
 
@@ -1329,13 +1322,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            ))
+            )
+        )
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
-                          entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1361,9 +1354,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(
-            FeedItem.id == existing_item_data.id).update(
-                updates, synchronize_session=False)
+        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
+            updates, synchronize_session=False
+        )
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1444,8 +1437,9 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug("Individually added item: %s",
-                         _sanitize_for_log(item.title[:50]))
+            logger.debug(
+                "Individually added item: %s", _sanitize_for_log(item.title[:50])
+            )
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1497,12 +1491,18 @@ def _enforce_feed_limit(feed_db_obj):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    ids_to_evict_rows = (db.session.query(
-        FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
+    ids_to_evict_rows = (
+        db.session.query(FeedItem.id)
+        .filter_by(feed_id=feed_db_obj.id)
+        .order_by(
             FeedItem.published_time.desc().nullslast(),
             FeedItem.fetched_time.desc().nullslast(),
             FeedItem.id.desc(),
-    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN).all())
+        )
+        .offset(MAX_ITEMS_PER_FEED)
+        .limit(EVICTION_LIMIT_PER_RUN)
+        .all()
+    )
 
     if not ids_to_evict_rows:
         return
@@ -1513,9 +1513,12 @@ def _enforce_feed_limit(feed_db_obj):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i:i + chunk_size]
-        deleted_count += (db.session.query(FeedItem).filter(
-            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
+        chunk = ids_to_evict[i : i + chunk_size]
+        deleted_count += (
+            db.session.query(FeedItem)
+            .filter(FeedItem.id.in_(chunk))
+            .delete(synchronize_session=False)
+        )
 
     if deleted_count > 0:
         logger.info(
@@ -1623,19 +1626,15 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).",
-                total_feeds)
+    logger.info("Starting update process for %d feeds (Parallelized).", total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
-    actual_workers = min(MAX_CONCURRENT_FETCHES,
-                         total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(
-            max_workers=actual_workers) as executor:
+    actual_workers = min(MAX_CONCURRENT_FETCHES, total_feeds) if all_feeds else 1
+    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed
-            for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1649,7 +1648,8 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed)
+                    feed_obj, parsed_feed
+                )
                 if success:
                     successful_count += 1
                     total_new_items += new_items

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -1,5 +1,7 @@
 """Service module for fetching, parsing, and processing RSS/Atom feeds."""
 
+from __future__ import annotations
+
 # Import necessary libraries
 # Use dateutil for robust date parsing
 import concurrent.futures
@@ -15,10 +17,10 @@ import ssl
 import urllib.request
 from dataclasses import dataclass
 from datetime import timezone  # Specifically import timezone
-from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlparse
 from xml.sax import SAXParseException
 from xml.sax.handler import ContentHandler
+from xml.etree.ElementTree import Element  # skipcq: BAN-B405
 
 import defusedxml.ElementTree as SafeET
 import defusedxml.sax
@@ -51,11 +53,9 @@ from .sse import announcer
 # Set up logger for this module
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:
-    from xml.etree.ElementTree import Element  # skipcq: BAN-B405
 
 # Type alias for the stack items: (list of XML elements, current_tab_id, current_tab_name)
-OpmlStackItem = tuple[list["Element"], int, str]
+OpmlStackItem = tuple[list[Element], int, str]
 
 
 @dataclass


### PR DESCRIPTION
🎯 **What:** Fixed `F401 'xml.etree.ElementTree.Element' imported but unused` in `backend/feed_service.py`.

💡 **Why:** Linters like `flake8` report unused imports when they are only referenced in type hints encapsulated inside strings, such as `list["Element"]`. Utilizing `from __future__ import annotations` natively prevents type hints from being evaluated at runtime without putting them inside quotes, which elegantly resolves the unused import issue without violating coding standards or modifying behavior.

✅ **Verification:** Verified by checking the backend test suite via `pytest` and re-linting the file locally.

✨ **Result:** A cleaner codebase with fewer linter complaints and better explicit types.

---
*PR created automatically by Jules for task [8707288501623034142](https://jules.google.com/task/8707288501623034142) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Simplify the OpmlStackItem type alias by using the Element type directly instead of a string-based forward reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization and formatting throughout feed service operations for better readability and maintainability. Updated expression formatting in import operations, feed processing workflows, error handling, and logging functionality.

* **Chores**
  * Updated internal dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/SheepVibes/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->