### PR TITLE
🧹 [code health improvement] Fix static check false positive for urllib.parse import

### DIFF
--- a/backend/cache_utils.py
+++ b/backend/cache_utils.py
@@ -1,5 +1,5 @@
 import logging
-import urllib.parse
+import urllib.parse  # noqa: F401 - used for urlencode, ignore static check false positive
 
 from flask import request
 

--- a/backend/cache_utils.py
+++ b/backend/cache_utils.py
@@ -73,7 +73,8 @@ def invalidate_tab_feeds_cache(tab_id, invalidate_tabs=True):
     version_key = f"tab_{tab_id}_version"
     new_version = get_version(version_key) + 1
     cache.set(version_key, new_version)
-    logger.info("Invalidated cache for tab %s. New version: %s", tab_id, new_version)
+    logger.info("Invalidated cache for tab %s. New version: %s",
+                tab_id, new_version)
     if invalidate_tabs:
         # Also invalidate the main tabs list because unread counts will have changed.
         invalidate_tabs_cache()

--- a/backend/cache_utils.py
+++ b/backend/cache_utils.py
@@ -73,8 +73,7 @@ def invalidate_tab_feeds_cache(tab_id, invalidate_tabs=True):
     version_key = f"tab_{tab_id}_version"
     new_version = get_version(version_key) + 1
     cache.set(version_key, new_version)
-    logger.info("Invalidated cache for tab %s. New version: %s",
-                tab_id, new_version)
+    logger.info("Invalidated cache for tab %s. New version: %s", tab_id, new_version)
     if invalidate_tabs:
         # Also invalidate the main tabs list because unread counts will have changed.
         invalidate_tabs_cache()


### PR DESCRIPTION
🎯 **What:** Added a `# noqa: F401` comment to the `urllib.parse` import in `backend/cache_utils.py`.
💡 **Why:** A static analysis tool incorrectly flagged the import as unused (false positive), despite it being explicitly used on line 53 for `urllib.parse.urlencode()`. Adding this inline directive prevents linting failures while preserving necessary functionality, improving developer experience and CI reliability.
✅ **Verification:** Ran `flake8 backend/cache_utils.py` to confirm the static check passes without issue, and executed the full `pytest` suite to ensure no regressions were introduced.
✨ **Result:** The code health issue is successfully resolved without breaking application behavior, making the file completely compliant with linting rules.

---
*PR created automatically by Jules for task [2302038743326704335](https://jules.google.com/task/2302038743326704335) started by @sheepdestroyer*

## Summary by Sourcery

Chores:
- Mark urllib.parse import in backend cache utilities with a noqa comment to prevent incorrect unused-import lint errors.