### PR TITLE
🧹 [Code Health] Refactor process_feed_entries

### DIFF
--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -111,9 +111,8 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(
-    processed_count, total_count, last_announced_percent
-):
+def _calculate_and_announce_progress(processed_count, total_count,
+                                     last_announced_percent):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -125,12 +124,10 @@ def _calculate_and_announce_progress(
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (
-        processed_count == 0
-        or processed_count >= total_count
-        or (current_percent != last_announced_percent and current_percent % 5 == 0)
-        or processed_count % 20 == 0
-    )
+    should_announce = (processed_count == 0 or processed_count >= total_count
+                       or (current_percent != last_announced_percent
+                           and current_percent % 5 == 0)
+                       or processed_count % 20 == 0)
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -236,10 +233,10 @@ def _process_folder_node(
 
     if element_name and child_outlines:
         try:
-            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(element_name)
-            state.stack.append(
-                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
-            )
+            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
+                element_name)
+            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
+                                nested_tab_name))
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -249,8 +246,7 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
-        )
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
         return
 
     state.skipped_count += 1
@@ -291,13 +287,11 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [
-        (
-            list(reversed(initial_outline_elements)),
-            top_level_tab_id,
-            top_level_tab_name,
-        )
-    ]
+    stack = [(
+        list(reversed(initial_outline_elements)),
+        top_level_tab_id,
+        top_level_tab_name,
+    )]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -315,8 +309,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines, last_announced_percent
-            )
+                processed_outline_count, total_outlines,
+                last_announced_percent)
 
             _process_single_outline_node(
                 outline_element,
@@ -370,15 +364,13 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation
-            ).first()
+                name=default_tab_name_for_creation).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0
-                )
+                    name=default_tab_name_for_creation, order=0)
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -403,8 +395,7 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation
-                    ).first()
+                        name=default_tab_name_for_creation).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -420,7 +411,10 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {"error": "Failed to create a default tab for import."},
+                                {
+                                    "error":
+                                    "Failed to create a default tab for import."
+                                },
                                 500,
                             ),
                         )
@@ -435,7 +429,10 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {"error": "Failed to create a default tab for import."},
+                            {
+                                "error":
+                                "Failed to create a default tab for import."
+                            },
                             500,
                         ),
                     )
@@ -448,13 +445,16 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({"error": "Failed to determine a target tab for import."}, 500),
+            ({
+                "error": "Failed to determine a target tab for import."
+            }, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
+                               affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -485,9 +485,13 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except SafeET.ParseError as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
+        logger.error("OPML import failed: Malformed XML. Error: %s",
+                     e,
+                     exc_info=True)
         return None, (
-            {"error": "Malformed OPML file. Please check the file format."},
+            {
+                "error": "Malformed OPML file. Please check the file format."
+            },
             400,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -497,7 +501,10 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {"error": "Could not parse OPML file. Please check the file format."},
+            {
+                "error":
+                "Could not parse OPML file. Please check the file format."
+            },
             400,
         )
 
@@ -520,13 +527,13 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
-                )
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i + 1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
+                                                                    1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -556,7 +563,9 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {"error": "Database error during final feed import step."},
+            {
+                "error": "Database error during final feed import step."
+            },
             500,
         )
 
@@ -622,8 +631,7 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list
-    )
+        state.newly_added_feeds_list)
     if not success:
         return None, error_resp
 
@@ -639,7 +647,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     )
 
     if not opml_body.findall("outline") and not state.newly_added_feeds_list:
-        logger.info("OPML import: No <outline> elements found in the OPML body.")
+        logger.info(
+            "OPML import: No <outline> elements found in the OPML body.")
         result = {
             "message": "No feed entries or folders found in the OPML file.",
             "imported_count": 0,
@@ -656,13 +665,19 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message":
+        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count": imported_final_count,
-        "skipped_count": skipped_final_count,
-        "tab_id": top_level_target_tab_id,
-        "tab_name": top_level_target_tab_name,
-        "affected_tab_ids": list(state.affected_tab_ids_set),
+        "imported_count":
+        imported_final_count,
+        "skipped_count":
+        skipped_final_count,
+        "tab_id":
+        top_level_target_tab_id,
+        "tab_name":
+        top_level_target_tab_name,
+        "affected_tab_ids":
+        list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -736,7 +751,8 @@ def _validate_xml_safety(content):
             forbid_external=True,
         )
     except (DTDForbidden, EntitiesForbidden, ExternalReferenceForbidden) as e:
-        logger.error("XML Security Violation detected: %s", _sanitize_for_log(str(e)))
+        logger.error("XML Security Violation detected: %s",
+                     _sanitize_for_log(str(e)))
         return False
     except (SAXParseException, UnicodeError) as e:
         # SECURITY HARDENING: Fail closed on malformed XML.
@@ -784,7 +800,8 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
+                parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -844,14 +861,8 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_reserved
-        or ip.is_multicast
-        or ip.is_unspecified
-    )
+    return not (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -882,9 +893,8 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection(
-            (self.safe_ip, self.port), self.timeout, self.source_address
-        )
+        self.sock = socket.create_connection((self.safe_ip, self.port),
+                                             self.timeout, self.source_address)
 
         if self._tunnel_host:
             self._tunnel()
@@ -920,9 +930,8 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection(
-            (self.safe_ip, self.port), self.timeout, self.source_address
-        )
+        self.sock = socket.create_connection((self.safe_ip, self.port),
+                                             self.timeout, self.source_address)
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -986,15 +995,15 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning(
-                "Blocked unsafe redirect to: %s", _sanitize_for_log(absolute_newurl)
-            )
-            raise urllib.error.HTTPError(
-                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
-            )
+            logger.warning("Blocked unsafe redirect to: %s",
+                           _sanitize_for_log(absolute_newurl))
+            raise urllib.error.HTTPError(absolute_newurl, code,
+                                         "Blocked unsafe redirect", headers,
+                                         fp)
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers,
+                                           absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1023,9 +1032,8 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception(
-            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
-        )
+        logger.exception("Error in fetch thread for feed %s",
+                         _sanitize_for_log(feed_url))
         return None
 
 
@@ -1104,9 +1112,8 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(
-            http_handler, https_handler, redirect_handler
-        )
+        opener = urllib.request.build_opener(http_handler, https_handler,
+                                             redirect_handler)
 
         req = urllib.request.Request(
             feed_url,
@@ -1161,7 +1168,8 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s", safe_log_url)
+            logger.warning("Feed rejected due to security violation: %s",
+                           safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1169,7 +1177,8 @@ def fetch_feed(feed_url):
         if parsed_feed.bozo:
             # Check for bozo_exception and sanitize it (it can contain malicious input)
             bozo_exc = parsed_feed.get("bozo_exception")
-            safe_exc_msg = _sanitize_for_log(str(bozo_exc)) if bozo_exc else "Unknown"
+            safe_exc_msg = _sanitize_for_log(
+                str(bozo_exc)) if bozo_exc else "Unknown"
             logger.warning("Feed parsing warning: %s", safe_exc_msg)
 
         return parsed_feed
@@ -1225,11 +1234,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (
-        db.session.query(FeedItem.id, FeedItem.guid, FeedItem.link, FeedItem.title)
-        .filter_by(feed_id=feed_db_obj.id)
-        .all()
-    )
+    items_tuple = (db.session.query(
+        FeedItem.id, FeedItem.guid, FeedItem.link,
+        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1256,9 +1263,8 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning(
-            "Failed to sort entries for feed %s", _sanitize_for_log(feed_db_obj.name)
-        )
+        logger.warning("Failed to sort entries for feed %s",
+                       _sanitize_for_log(feed_db_obj.name))
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1307,9 +1313,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-            db_guid,
-            batch_processed_guids,
-            feed_db_obj.name,
+                db_guid,
+                batch_processed_guids,
+                feed_db_obj.name,
         ):
             continue
 
@@ -1323,13 +1329,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            )
-        )
+            ))
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
+                          entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1355,9 +1361,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_li
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
-            updates, synchronize_session=False
-        )
+        db.session.query(FeedItem).filter(
+            FeedItem.id == existing_item_data.id).update(
+                updates, synchronize_session=False)
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1438,9 +1444,8 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug(
-                "Individually added item: %s", _sanitize_for_log(item.title[:50])
-            )
+            logger.debug("Individually added item: %s",
+                         _sanitize_for_log(item.title[:50]))
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1492,18 +1497,12 @@ def _enforce_feed_limit(feed_db_obj):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    ids_to_evict_rows = (
-        db.session.query(FeedItem.id)
-        .filter_by(feed_id=feed_db_obj.id)
-        .order_by(
+    ids_to_evict_rows = (db.session.query(
+        FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
             FeedItem.published_time.desc().nullslast(),
             FeedItem.fetched_time.desc().nullslast(),
             FeedItem.id.desc(),
-        )
-        .offset(MAX_ITEMS_PER_FEED)
-        .limit(EVICTION_LIMIT_PER_RUN)
-        .all()
-    )
+    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN).all())
 
     if not ids_to_evict_rows:
         return
@@ -1514,12 +1513,9 @@ def _enforce_feed_limit(feed_db_obj):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i : i + chunk_size]
-        deleted_count += (
-            db.session.query(FeedItem)
-            .filter(FeedItem.id.in_(chunk))
-            .delete(synchronize_session=False)
-        )
+        chunk = ids_to_evict[i:i + chunk_size]
+        deleted_count += (db.session.query(FeedItem).filter(
+            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
 
     if deleted_count > 0:
         logger.info(
@@ -1640,15 +1636,19 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).", total_feeds)
+    logger.info("Starting update process for %d feeds (Parallelized).",
+                total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
-    actual_workers = min(MAX_CONCURRENT_FETCHES, total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
+    actual_workers = min(MAX_CONCURRENT_FETCHES,
+                         total_feeds) if all_feeds else 1
+    with concurrent.futures.ThreadPoolExecutor(
+            max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed
+            for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1662,8 +1662,7 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed
-                )
+                    feed_obj, parsed_feed)
                 if success:
                     successful_count += 1
                     total_new_items += new_items

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -111,9 +111,8 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(
-    processed_count, total_count, last_announced_percent
-):
+def _calculate_and_announce_progress(processed_count, total_count,
+                                     last_announced_percent):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -125,12 +124,10 @@ def _calculate_and_announce_progress(
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (
-        processed_count == 0
-        or processed_count >= total_count
-        or (current_percent != last_announced_percent and current_percent % 5 == 0)
-        or processed_count % 20 == 0
-    )
+    should_announce = (processed_count == 0 or processed_count >= total_count
+                       or (current_percent != last_announced_percent
+                           and current_percent % 5 == 0)
+                       or processed_count % 20 == 0)
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -236,10 +233,10 @@ def _process_folder_node(
 
     if element_name and child_outlines:
         try:
-            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(element_name)
-            state.stack.append(
-                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
-            )
+            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
+                element_name)
+            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
+                                nested_tab_name))
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -249,8 +246,7 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
-        )
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
         return
 
     state.skipped_count += 1
@@ -291,13 +287,11 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [
-        (
-            list(reversed(initial_outline_elements)),
-            top_level_tab_id,
-            top_level_tab_name,
-        )
-    ]
+    stack = [(
+        list(reversed(initial_outline_elements)),
+        top_level_tab_id,
+        top_level_tab_name,
+    )]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -315,8 +309,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines, last_announced_percent
-            )
+                processed_outline_count, total_outlines,
+                last_announced_percent)
 
             _process_single_outline_node(
                 outline_element,
@@ -370,15 +364,13 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation
-            ).first()
+                name=default_tab_name_for_creation).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0
-                )
+                    name=default_tab_name_for_creation, order=0)
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -403,8 +395,7 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation
-                    ).first()
+                        name=default_tab_name_for_creation).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -420,7 +411,10 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {"error": "Failed to create a default tab for import."},
+                                {
+                                    "error":
+                                    "Failed to create a default tab for import."
+                                },
                                 500,
                             ),
                         )
@@ -435,7 +429,10 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {"error": "Failed to create a default tab for import."},
+                            {
+                                "error":
+                                "Failed to create a default tab for import."
+                            },
                             500,
                         ),
                     )
@@ -448,13 +445,16 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({"error": "Failed to determine a target tab for import."}, 500),
+            ({
+                "error": "Failed to determine a target tab for import."
+            }, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
+                               affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -485,9 +485,13 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except SafeET.ParseError as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
+        logger.error("OPML import failed: Malformed XML. Error: %s",
+                     e,
+                     exc_info=True)
         return None, (
-            {"error": "Malformed OPML file. Please check the file format."},
+            {
+                "error": "Malformed OPML file. Please check the file format."
+            },
             400,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -497,7 +501,10 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {"error": "Could not parse OPML file. Please check the file format."},
+            {
+                "error":
+                "Could not parse OPML file. Please check the file format."
+            },
             400,
         )
 
@@ -520,13 +527,13 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
-                )
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i + 1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
+                                                                    1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -556,7 +563,9 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {"error": "Database error during final feed import step."},
+            {
+                "error": "Database error during final feed import step."
+            },
             500,
         )
 
@@ -622,8 +631,7 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list
-    )
+        state.newly_added_feeds_list)
     if not success:
         return None, error_resp
 
@@ -639,7 +647,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     )
 
     if not opml_body.findall("outline") and not state.newly_added_feeds_list:
-        logger.info("OPML import: No <outline> elements found in the OPML body.")
+        logger.info(
+            "OPML import: No <outline> elements found in the OPML body.")
         result = {
             "message": "No feed entries or folders found in the OPML file.",
             "imported_count": 0,
@@ -656,13 +665,19 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message":
+        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count": imported_final_count,
-        "skipped_count": skipped_final_count,
-        "tab_id": top_level_target_tab_id,
-        "tab_name": top_level_target_tab_name,
-        "affected_tab_ids": list(state.affected_tab_ids_set),
+        "imported_count":
+        imported_final_count,
+        "skipped_count":
+        skipped_final_count,
+        "tab_id":
+        top_level_target_tab_id,
+        "tab_name":
+        top_level_target_tab_name,
+        "affected_tab_ids":
+        list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -736,7 +751,8 @@ def _validate_xml_safety(content):
             forbid_external=True,
         )
     except (DTDForbidden, EntitiesForbidden, ExternalReferenceForbidden) as e:
-        logger.error("XML Security Violation detected: %s", _sanitize_for_log(str(e)))
+        logger.error("XML Security Violation detected: %s",
+                     _sanitize_for_log(str(e)))
         return False
     except (SAXParseException, UnicodeError) as e:
         # SECURITY HARDENING: Fail closed on malformed XML.
@@ -784,7 +800,8 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
+                parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -844,14 +861,8 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_reserved
-        or ip.is_multicast
-        or ip.is_unspecified
-    )
+    return not (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -882,9 +893,8 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection(
-            (self.safe_ip, self.port), self.timeout, self.source_address
-        )
+        self.sock = socket.create_connection((self.safe_ip, self.port),
+                                             self.timeout, self.source_address)
 
         if self._tunnel_host:
             self._tunnel()
@@ -920,9 +930,8 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection(
-            (self.safe_ip, self.port), self.timeout, self.source_address
-        )
+        self.sock = socket.create_connection((self.safe_ip, self.port),
+                                             self.timeout, self.source_address)
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -986,15 +995,15 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning(
-                "Blocked unsafe redirect to: %s", _sanitize_for_log(absolute_newurl)
-            )
-            raise urllib.error.HTTPError(
-                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
-            )
+            logger.warning("Blocked unsafe redirect to: %s",
+                           _sanitize_for_log(absolute_newurl))
+            raise urllib.error.HTTPError(absolute_newurl, code,
+                                         "Blocked unsafe redirect", headers,
+                                         fp)
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers,
+                                           absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1023,9 +1032,8 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception(
-            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
-        )
+        logger.exception("Error in fetch thread for feed %s",
+                         _sanitize_for_log(feed_url))
         return None
 
 
@@ -1104,9 +1112,8 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(
-            http_handler, https_handler, redirect_handler
-        )
+        opener = urllib.request.build_opener(http_handler, https_handler,
+                                             redirect_handler)
 
         req = urllib.request.Request(
             feed_url,
@@ -1161,7 +1168,8 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s", safe_log_url)
+            logger.warning("Feed rejected due to security violation: %s",
+                           safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1169,7 +1177,8 @@ def fetch_feed(feed_url):
         if parsed_feed.bozo:
             # Check for bozo_exception and sanitize it (it can contain malicious input)
             bozo_exc = parsed_feed.get("bozo_exception")
-            safe_exc_msg = _sanitize_for_log(str(bozo_exc)) if bozo_exc else "Unknown"
+            safe_exc_msg = _sanitize_for_log(
+                str(bozo_exc)) if bozo_exc else "Unknown"
             logger.warning("Feed parsing warning: %s", safe_exc_msg)
 
         return parsed_feed
@@ -1225,11 +1234,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (
-        db.session.query(FeedItem.id, FeedItem.guid, FeedItem.link, FeedItem.title)
-        .filter_by(feed_id=feed_db_obj.id)
-        .all()
-    )
+    items_tuple = (db.session.query(
+        FeedItem.id, FeedItem.guid, FeedItem.link,
+        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1256,9 +1263,8 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning(
-            "Failed to sort entries for feed %s", _sanitize_for_log(feed_db_obj.name)
-        )
+        logger.warning("Failed to sort entries for feed %s",
+                       _sanitize_for_log(feed_db_obj.name))
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1307,9 +1313,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-            db_guid,
-            batch_processed_guids,
-            feed_db_obj.name,
+                db_guid,
+                batch_processed_guids,
+                feed_db_obj.name,
         ):
             continue
 
@@ -1323,13 +1329,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            )
-        )
+            ))
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
+                          entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1355,9 +1361,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_li
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
-            updates, synchronize_session=False
-        )
+        db.session.query(FeedItem).filter(
+            FeedItem.id == existing_item_data.id).update(
+                updates, synchronize_session=False)
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1438,9 +1444,8 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug(
-                "Individually added item: %s", _sanitize_for_log(item.title[:50])
-            )
+            logger.debug("Individually added item: %s",
+                         _sanitize_for_log(item.title[:50]))
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1492,18 +1497,12 @@ def _enforce_feed_limit(feed_db_obj):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    ids_to_evict_rows = (
-        db.session.query(FeedItem.id)
-        .filter_by(feed_id=feed_db_obj.id)
-        .order_by(
+    ids_to_evict_rows = (db.session.query(
+        FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
             FeedItem.published_time.desc().nullslast(),
             FeedItem.fetched_time.desc().nullslast(),
             FeedItem.id.desc(),
-        )
-        .offset(MAX_ITEMS_PER_FEED)
-        .limit(EVICTION_LIMIT_PER_RUN)
-        .all()
-    )
+    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN).all())
 
     if not ids_to_evict_rows:
         return
@@ -1514,12 +1513,9 @@ def _enforce_feed_limit(feed_db_obj):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i : i + chunk_size]
-        deleted_count += (
-            db.session.query(FeedItem)
-            .filter(FeedItem.id.in_(chunk))
-            .delete(synchronize_session=False)
-        )
+        chunk = ids_to_evict[i:i + chunk_size]
+        deleted_count += (db.session.query(FeedItem).filter(
+            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
 
     if deleted_count > 0:
         logger.info(
@@ -1554,7 +1550,8 @@ def _commit_metadata(feed_db_obj):
     This ensures they are preserved even if the batch insert of new items fails later.
     """
     return _commit_with_rollback(
-        "Error committing metadata/existing items for feed %s", feed_db_obj.name
+        "Error committing metadata/existing items for feed %s",
+        feed_db_obj.name
     )
 
 
@@ -1564,7 +1561,8 @@ def _update_timestamp_no_new_items(feed_db_obj):
     # or here if there were no items but fetch succeeded.
     feed_db_obj.last_updated_time = datetime.datetime.now(timezone.utc)
     _commit_with_rollback(
-        "Error committing feed update (no new items) for %s", feed_db_obj.name
+        "Error committing feed update (no new items) for %s",
+        feed_db_obj.name
     )
 
 
@@ -1639,15 +1637,19 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).", total_feeds)
+    logger.info("Starting update process for %d feeds (Parallelized).",
+                total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
-    actual_workers = min(MAX_CONCURRENT_FETCHES, total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
+    actual_workers = min(MAX_CONCURRENT_FETCHES,
+                         total_feeds) if all_feeds else 1
+    with concurrent.futures.ThreadPoolExecutor(
+            max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed
+            for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1661,8 +1663,7 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed
-                )
+                    feed_obj, parsed_feed)
                 if success:
                     successful_count += 1
                     total_new_items += new_items

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -111,9 +111,8 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(
-    processed_count, total_count, last_announced_percent
-):
+def _calculate_and_announce_progress(processed_count, total_count,
+                                     last_announced_percent):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -125,12 +124,10 @@ def _calculate_and_announce_progress(
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (
-        processed_count == 0
-        or processed_count >= total_count
-        or (current_percent != last_announced_percent and current_percent % 5 == 0)
-        or processed_count % 20 == 0
-    )
+    should_announce = (processed_count == 0 or processed_count >= total_count
+                       or (current_percent != last_announced_percent
+                           and current_percent % 5 == 0)
+                       or processed_count % 20 == 0)
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -236,10 +233,10 @@ def _process_folder_node(
 
     if element_name and child_outlines:
         try:
-            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(element_name)
-            state.stack.append(
-                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
-            )
+            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
+                element_name)
+            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
+                                nested_tab_name))
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -249,8 +246,7 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
-        )
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
         return
 
     state.skipped_count += 1
@@ -291,13 +287,11 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [
-        (
-            list(reversed(initial_outline_elements)),
-            top_level_tab_id,
-            top_level_tab_name,
-        )
-    ]
+    stack = [(
+        list(reversed(initial_outline_elements)),
+        top_level_tab_id,
+        top_level_tab_name,
+    )]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -315,8 +309,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines, last_announced_percent
-            )
+                processed_outline_count, total_outlines,
+                last_announced_percent)
 
             _process_single_outline_node(
                 outline_element,
@@ -370,15 +364,13 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation
-            ).first()
+                name=default_tab_name_for_creation).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0
-                )
+                    name=default_tab_name_for_creation, order=0)
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -403,8 +395,7 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation
-                    ).first()
+                        name=default_tab_name_for_creation).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -420,7 +411,10 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {"error": "Failed to create a default tab for import."},
+                                {
+                                    "error":
+                                    "Failed to create a default tab for import."
+                                },
                                 500,
                             ),
                         )
@@ -435,7 +429,10 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {"error": "Failed to create a default tab for import."},
+                            {
+                                "error":
+                                "Failed to create a default tab for import."
+                            },
                             500,
                         ),
                     )
@@ -448,13 +445,16 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({"error": "Failed to determine a target tab for import."}, 500),
+            ({
+                "error": "Failed to determine a target tab for import."
+            }, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
+                               affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -485,9 +485,13 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except SafeET.ParseError as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
+        logger.error("OPML import failed: Malformed XML. Error: %s",
+                     e,
+                     exc_info=True)
         return None, (
-            {"error": "Malformed OPML file. Please check the file format."},
+            {
+                "error": "Malformed OPML file. Please check the file format."
+            },
             400,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -497,7 +501,10 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {"error": "Could not parse OPML file. Please check the file format."},
+            {
+                "error":
+                "Could not parse OPML file. Please check the file format."
+            },
             400,
         )
 
@@ -520,13 +527,13 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
-                )
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i + 1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
+                                                                    1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -556,7 +563,9 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {"error": "Database error during final feed import step."},
+            {
+                "error": "Database error during final feed import step."
+            },
             500,
         )
 
@@ -622,8 +631,7 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list
-    )
+        state.newly_added_feeds_list)
     if not success:
         return None, error_resp
 
@@ -639,7 +647,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     )
 
     if not opml_body.findall("outline") and not state.newly_added_feeds_list:
-        logger.info("OPML import: No <outline> elements found in the OPML body.")
+        logger.info(
+            "OPML import: No <outline> elements found in the OPML body.")
         result = {
             "message": "No feed entries or folders found in the OPML file.",
             "imported_count": 0,
@@ -656,13 +665,19 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message":
+        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count": imported_final_count,
-        "skipped_count": skipped_final_count,
-        "tab_id": top_level_target_tab_id,
-        "tab_name": top_level_target_tab_name,
-        "affected_tab_ids": list(state.affected_tab_ids_set),
+        "imported_count":
+        imported_final_count,
+        "skipped_count":
+        skipped_final_count,
+        "tab_id":
+        top_level_target_tab_id,
+        "tab_name":
+        top_level_target_tab_name,
+        "affected_tab_ids":
+        list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -736,7 +751,8 @@ def _validate_xml_safety(content):
             forbid_external=True,
         )
     except (DTDForbidden, EntitiesForbidden, ExternalReferenceForbidden) as e:
-        logger.error("XML Security Violation detected: %s", _sanitize_for_log(str(e)))
+        logger.error("XML Security Violation detected: %s",
+                     _sanitize_for_log(str(e)))
         return False
     except (SAXParseException, UnicodeError) as e:
         # SECURITY HARDENING: Fail closed on malformed XML.
@@ -784,7 +800,8 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
+                parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -844,14 +861,8 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_reserved
-        or ip.is_multicast
-        or ip.is_unspecified
-    )
+    return not (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -882,9 +893,8 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection(
-            (self.safe_ip, self.port), self.timeout, self.source_address
-        )
+        self.sock = socket.create_connection((self.safe_ip, self.port),
+                                             self.timeout, self.source_address)
 
         if self._tunnel_host:
             self._tunnel()
@@ -920,9 +930,8 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection(
-            (self.safe_ip, self.port), self.timeout, self.source_address
-        )
+        self.sock = socket.create_connection((self.safe_ip, self.port),
+                                             self.timeout, self.source_address)
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -986,15 +995,15 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning(
-                "Blocked unsafe redirect to: %s", _sanitize_for_log(absolute_newurl)
-            )
-            raise urllib.error.HTTPError(
-                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
-            )
+            logger.warning("Blocked unsafe redirect to: %s",
+                           _sanitize_for_log(absolute_newurl))
+            raise urllib.error.HTTPError(absolute_newurl, code,
+                                         "Blocked unsafe redirect", headers,
+                                         fp)
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers,
+                                           absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1023,9 +1032,8 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception(
-            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
-        )
+        logger.exception("Error in fetch thread for feed %s",
+                         _sanitize_for_log(feed_url))
         return None
 
 
@@ -1104,9 +1112,8 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(
-            http_handler, https_handler, redirect_handler
-        )
+        opener = urllib.request.build_opener(http_handler, https_handler,
+                                             redirect_handler)
 
         req = urllib.request.Request(
             feed_url,
@@ -1161,7 +1168,8 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s", safe_log_url)
+            logger.warning("Feed rejected due to security violation: %s",
+                           safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1169,7 +1177,8 @@ def fetch_feed(feed_url):
         if parsed_feed.bozo:
             # Check for bozo_exception and sanitize it (it can contain malicious input)
             bozo_exc = parsed_feed.get("bozo_exception")
-            safe_exc_msg = _sanitize_for_log(str(bozo_exc)) if bozo_exc else "Unknown"
+            safe_exc_msg = _sanitize_for_log(
+                str(bozo_exc)) if bozo_exc else "Unknown"
             logger.warning("Feed parsing warning: %s", safe_exc_msg)
 
         return parsed_feed
@@ -1225,11 +1234,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (
-        db.session.query(FeedItem.id, FeedItem.guid, FeedItem.link, FeedItem.title)
-        .filter_by(feed_id=feed_db_obj.id)
-        .all()
-    )
+    items_tuple = (db.session.query(
+        FeedItem.id, FeedItem.guid, FeedItem.link,
+        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1256,9 +1263,8 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning(
-            "Failed to sort entries for feed %s", _sanitize_for_log(feed_db_obj.name)
-        )
+        logger.warning("Failed to sort entries for feed %s",
+                       _sanitize_for_log(feed_db_obj.name))
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1307,9 +1313,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-            db_guid,
-            batch_processed_guids,
-            feed_db_obj.name,
+                db_guid,
+                batch_processed_guids,
+                feed_db_obj.name,
         ):
             continue
 
@@ -1323,13 +1329,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            )
-        )
+            ))
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
+                          entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1355,9 +1361,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_li
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
-            updates, synchronize_session=False
-        )
+        db.session.query(FeedItem).filter(
+            FeedItem.id == existing_item_data.id).update(
+                updates, synchronize_session=False)
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1438,9 +1444,8 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug(
-                "Individually added item: %s", _sanitize_for_log(item.title[:50])
-            )
+            logger.debug("Individually added item: %s",
+                         _sanitize_for_log(item.title[:50]))
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1492,18 +1497,12 @@ def _enforce_feed_limit(feed_db_obj):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    ids_to_evict_rows = (
-        db.session.query(FeedItem.id)
-        .filter_by(feed_id=feed_db_obj.id)
-        .order_by(
+    ids_to_evict_rows = (db.session.query(
+        FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
             FeedItem.published_time.desc().nullslast(),
             FeedItem.fetched_time.desc().nullslast(),
             FeedItem.id.desc(),
-        )
-        .offset(MAX_ITEMS_PER_FEED)
-        .limit(EVICTION_LIMIT_PER_RUN)
-        .all()
-    )
+    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN).all())
 
     if not ids_to_evict_rows:
         return
@@ -1514,12 +1513,9 @@ def _enforce_feed_limit(feed_db_obj):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i : i + chunk_size]
-        deleted_count += (
-            db.session.query(FeedItem)
-            .filter(FeedItem.id.in_(chunk))
-            .delete(synchronize_session=False)
-        )
+        chunk = ids_to_evict[i:i + chunk_size]
+        deleted_count += (db.session.query(FeedItem).filter(
+            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
 
     if deleted_count > 0:
         logger.info(
@@ -1539,12 +1535,14 @@ def _enforce_feed_limit(feed_db_obj):
 
 def _commit_with_rollback(error_msg, feed_name):
     """Helper to safely commit the db session with rollback on failure."""
+    # Extract properties before commit to avoid DetachedInstanceError or expired session issues after rollback
+    safe_name = _sanitize_for_log(feed_name)
     try:
         db.session.commit()
         return True
     except sqlalchemy.exc.SQLAlchemyError:
         db.session.rollback()
-        logger.exception(error_msg, _sanitize_for_log(feed_name))
+        logger.exception(error_msg, safe_name)
         return False
 
 
@@ -1554,7 +1552,8 @@ def _commit_metadata(feed_db_obj):
     This ensures they are preserved even if the batch insert of new items fails later.
     """
     return _commit_with_rollback(
-        "Error committing metadata/existing items for feed %s", feed_db_obj.name
+        "Error committing metadata/existing items for feed %s",
+        feed_db_obj.name
     )
 
 
@@ -1564,7 +1563,8 @@ def _update_timestamp_no_new_items(feed_db_obj):
     # or here if there were no items but fetch succeeded.
     feed_db_obj.last_updated_time = datetime.datetime.now(timezone.utc)
     _commit_with_rollback(
-        "Error committing feed update (no new items) for %s", feed_db_obj.name
+        "Error committing feed update (no new items) for %s",
+        feed_db_obj.name
     )
 
 
@@ -1639,15 +1639,19 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).", total_feeds)
+    logger.info("Starting update process for %d feeds (Parallelized).",
+                total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
-    actual_workers = min(MAX_CONCURRENT_FETCHES, total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
+    actual_workers = min(MAX_CONCURRENT_FETCHES,
+                         total_feeds) if all_feeds else 1
+    with concurrent.futures.ThreadPoolExecutor(
+            max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed
+            for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1661,8 +1665,7 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed
-                )
+                    feed_obj, parsed_feed)
                 if success:
                     successful_count += 1
                     total_new_items += new_items

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -111,8 +111,9 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(processed_count, total_count,
-                                     last_announced_percent):
+def _calculate_and_announce_progress(
+    processed_count, total_count, last_announced_percent
+):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -124,10 +125,12 @@ def _calculate_and_announce_progress(processed_count, total_count,
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (processed_count == 0 or processed_count >= total_count
-                       or (current_percent != last_announced_percent
-                           and current_percent % 5 == 0)
-                       or processed_count % 20 == 0)
+    should_announce = (
+        processed_count == 0
+        or processed_count >= total_count
+        or (current_percent != last_announced_percent and current_percent % 5 == 0)
+        or processed_count % 20 == 0
+    )
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -233,10 +236,10 @@ def _process_folder_node(
 
     if element_name and child_outlines:
         try:
-            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
-                element_name)
-            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
-                                nested_tab_name))
+            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(element_name)
+            state.stack.append(
+                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
+            )
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -246,7 +249,8 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
+        )
         return
 
     state.skipped_count += 1
@@ -287,11 +291,13 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [(
-        list(reversed(initial_outline_elements)),
-        top_level_tab_id,
-        top_level_tab_name,
-    )]
+    stack = [
+        (
+            list(reversed(initial_outline_elements)),
+            top_level_tab_id,
+            top_level_tab_name,
+        )
+    ]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -309,8 +315,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines,
-                last_announced_percent)
+                processed_outline_count, total_outlines, last_announced_percent
+            )
 
             _process_single_outline_node(
                 outline_element,
@@ -364,13 +370,15 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation).first()
+                name=default_tab_name_for_creation
+            ).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0)
+                    name=default_tab_name_for_creation, order=0
+                )
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -395,7 +403,8 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation).first()
+                        name=default_tab_name_for_creation
+                    ).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -411,10 +420,7 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {
-                                    "error":
-                                    "Failed to create a default tab for import."
-                                },
+                                {"error": "Failed to create a default tab for import."},
                                 500,
                             ),
                         )
@@ -429,10 +435,7 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {
-                                "error":
-                                "Failed to create a default tab for import."
-                            },
+                            {"error": "Failed to create a default tab for import."},
                             500,
                         ),
                     )
@@ -445,16 +448,13 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({
-                "error": "Failed to determine a target tab for import."
-            }, 500),
+            ({"error": "Failed to determine a target tab for import."}, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
-                               affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -485,13 +485,9 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except SafeET.ParseError as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s",
-                     e,
-                     exc_info=True)
+        logger.error("OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
         return None, (
-            {
-                "error": "Malformed OPML file. Please check the file format."
-            },
+            {"error": "Malformed OPML file. Please check the file format."},
             400,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -501,10 +497,7 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {
-                "error":
-                "Could not parse OPML file. Please check the file format."
-            },
+            {"error": "Could not parse OPML file. Please check the file format."},
             400,
         )
 
@@ -527,13 +520,13 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
+                )
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
-                                                                    1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - 1 or (i + 1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -563,9 +556,7 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {
-                "error": "Database error during final feed import step."
-            },
+            {"error": "Database error during final feed import step."},
             500,
         )
 
@@ -631,7 +622,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list)
+        state.newly_added_feeds_list
+    )
     if not success:
         return None, error_resp
 
@@ -647,8 +639,7 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     )
 
     if not opml_body.findall("outline") and not state.newly_added_feeds_list:
-        logger.info(
-            "OPML import: No <outline> elements found in the OPML body.")
+        logger.info("OPML import: No <outline> elements found in the OPML body.")
         result = {
             "message": "No feed entries or folders found in the OPML file.",
             "imported_count": 0,
@@ -665,19 +656,13 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message":
-        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count":
-        imported_final_count,
-        "skipped_count":
-        skipped_final_count,
-        "tab_id":
-        top_level_target_tab_id,
-        "tab_name":
-        top_level_target_tab_name,
-        "affected_tab_ids":
-        list(state.affected_tab_ids_set),
+        "imported_count": imported_final_count,
+        "skipped_count": skipped_final_count,
+        "tab_id": top_level_target_tab_id,
+        "tab_name": top_level_target_tab_name,
+        "affected_tab_ids": list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -751,8 +736,7 @@ def _validate_xml_safety(content):
             forbid_external=True,
         )
     except (DTDForbidden, EntitiesForbidden, ExternalReferenceForbidden) as e:
-        logger.error("XML Security Violation detected: %s",
-                     _sanitize_for_log(str(e)))
+        logger.error("XML Security Violation detected: %s", _sanitize_for_log(str(e)))
         return False
     except (SAXParseException, UnicodeError) as e:
         # SECURITY HARDENING: Fail closed on malformed XML.
@@ -800,8 +784,7 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
-                parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -861,8 +844,14 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (ip.is_private or ip.is_loopback or ip.is_link_local
-                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -893,8 +882,9 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
         if self._tunnel_host:
             self._tunnel()
@@ -930,8 +920,9 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -995,15 +986,15 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning("Blocked unsafe redirect to: %s",
-                           _sanitize_for_log(absolute_newurl))
-            raise urllib.error.HTTPError(absolute_newurl, code,
-                                         "Blocked unsafe redirect", headers,
-                                         fp)
+            logger.warning(
+                "Blocked unsafe redirect to: %s", _sanitize_for_log(absolute_newurl)
+            )
+            raise urllib.error.HTTPError(
+                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
+            )
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers,
-                                           absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1032,8 +1023,9 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception("Error in fetch thread for feed %s",
-                         _sanitize_for_log(feed_url))
+        logger.exception(
+            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
+        )
         return None
 
 
@@ -1112,8 +1104,9 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(http_handler, https_handler,
-                                             redirect_handler)
+        opener = urllib.request.build_opener(
+            http_handler, https_handler, redirect_handler
+        )
 
         req = urllib.request.Request(
             feed_url,
@@ -1168,8 +1161,7 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s",
-                           safe_log_url)
+            logger.warning("Feed rejected due to security violation: %s", safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1177,8 +1169,7 @@ def fetch_feed(feed_url):
         if parsed_feed.bozo:
             # Check for bozo_exception and sanitize it (it can contain malicious input)
             bozo_exc = parsed_feed.get("bozo_exception")
-            safe_exc_msg = _sanitize_for_log(
-                str(bozo_exc)) if bozo_exc else "Unknown"
+            safe_exc_msg = _sanitize_for_log(str(bozo_exc)) if bozo_exc else "Unknown"
             logger.warning("Feed parsing warning: %s", safe_exc_msg)
 
         return parsed_feed
@@ -1234,9 +1225,11 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (db.session.query(
-        FeedItem.id, FeedItem.guid, FeedItem.link,
-        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
+    items_tuple = (
+        db.session.query(FeedItem.id, FeedItem.guid, FeedItem.link, FeedItem.title)
+        .filter_by(feed_id=feed_db_obj.id)
+        .all()
+    )
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1263,8 +1256,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning("Failed to sort entries for feed %s",
-                       _sanitize_for_log(feed_db_obj.name))
+        logger.warning(
+            "Failed to sort entries for feed %s", _sanitize_for_log(feed_db_obj.name)
+        )
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1313,9 +1307,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-                db_guid,
-                batch_processed_guids,
-                feed_db_obj.name,
+            db_guid,
+            batch_processed_guids,
+            feed_db_obj.name,
         ):
             continue
 
@@ -1329,13 +1323,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            ))
+            )
+        )
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
-                          entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1361,9 +1355,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(
-            FeedItem.id == existing_item_data.id).update(
-                updates, synchronize_session=False)
+        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
+            updates, synchronize_session=False
+        )
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1444,8 +1438,9 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug("Individually added item: %s",
-                         _sanitize_for_log(item.title[:50]))
+            logger.debug(
+                "Individually added item: %s", _sanitize_for_log(item.title[:50])
+            )
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1497,12 +1492,18 @@ def _enforce_feed_limit(feed_db_obj):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    ids_to_evict_rows = (db.session.query(
-        FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
+    ids_to_evict_rows = (
+        db.session.query(FeedItem.id)
+        .filter_by(feed_id=feed_db_obj.id)
+        .order_by(
             FeedItem.published_time.desc().nullslast(),
             FeedItem.fetched_time.desc().nullslast(),
             FeedItem.id.desc(),
-    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN).all())
+        )
+        .offset(MAX_ITEMS_PER_FEED)
+        .limit(EVICTION_LIMIT_PER_RUN)
+        .all()
+    )
 
     if not ids_to_evict_rows:
         return
@@ -1513,9 +1514,12 @@ def _enforce_feed_limit(feed_db_obj):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i:i + chunk_size]
-        deleted_count += (db.session.query(FeedItem).filter(
-            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
+        chunk = ids_to_evict[i : i + chunk_size]
+        deleted_count += (
+            db.session.query(FeedItem)
+            .filter(FeedItem.id.in_(chunk))
+            .delete(synchronize_session=False)
+        )
 
     if deleted_count > 0:
         logger.info(
@@ -1552,8 +1556,7 @@ def _commit_metadata(feed_db_obj):
     This ensures they are preserved even if the batch insert of new items fails later.
     """
     return _commit_with_rollback(
-        "Error committing metadata/existing items for feed %s",
-        feed_db_obj.name
+        "Error committing metadata/existing items for feed %s", feed_db_obj.name
     )
 
 
@@ -1563,8 +1566,7 @@ def _update_timestamp_no_new_items(feed_db_obj):
     # or here if there were no items but fetch succeeded.
     feed_db_obj.last_updated_time = datetime.datetime.now(timezone.utc)
     _commit_with_rollback(
-        "Error committing feed update (no new items) for %s",
-        feed_db_obj.name
+        "Error committing feed update (no new items) for %s", feed_db_obj.name
     )
 
 
@@ -1639,19 +1641,15 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).",
-                total_feeds)
+    logger.info("Starting update process for %d feeds (Parallelized).", total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
-    actual_workers = min(MAX_CONCURRENT_FETCHES,
-                         total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(
-            max_workers=actual_workers) as executor:
+    actual_workers = min(MAX_CONCURRENT_FETCHES, total_feeds) if all_feeds else 1
+    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed
-            for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1665,7 +1663,8 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed)
+                    feed_obj, parsed_feed
+                )
                 if success:
                     successful_count += 1
                     total_new_items += new_items

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -111,9 +111,8 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(
-    processed_count, total_count, last_announced_percent
-):
+def _calculate_and_announce_progress(processed_count, total_count,
+                                     last_announced_percent):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -125,12 +124,10 @@ def _calculate_and_announce_progress(
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (
-        processed_count == 0
-        or processed_count >= total_count
-        or (current_percent != last_announced_percent and current_percent % 5 == 0)
-        or processed_count % 20 == 0
-    )
+    should_announce = (processed_count == 0 or processed_count >= total_count
+                       or (current_percent != last_announced_percent
+                           and current_percent % 5 == 0)
+                       or processed_count % 20 == 0)
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -236,10 +233,10 @@ def _process_folder_node(
 
     if element_name and child_outlines:
         try:
-            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(element_name)
-            state.stack.append(
-                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
-            )
+            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
+                element_name)
+            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
+                                nested_tab_name))
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -249,8 +246,7 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
-        )
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
         return
 
     state.skipped_count += 1
@@ -291,13 +287,11 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [
-        (
-            list(reversed(initial_outline_elements)),
-            top_level_tab_id,
-            top_level_tab_name,
-        )
-    ]
+    stack = [(
+        list(reversed(initial_outline_elements)),
+        top_level_tab_id,
+        top_level_tab_name,
+    )]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -315,8 +309,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines, last_announced_percent
-            )
+                processed_outline_count, total_outlines,
+                last_announced_percent)
 
             _process_single_outline_node(
                 outline_element,
@@ -370,15 +364,13 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation
-            ).first()
+                name=default_tab_name_for_creation).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0
-                )
+                    name=default_tab_name_for_creation, order=0)
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -403,8 +395,7 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation
-                    ).first()
+                        name=default_tab_name_for_creation).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -420,7 +411,10 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {"error": "Failed to create a default tab for import."},
+                                {
+                                    "error":
+                                    "Failed to create a default tab for import."
+                                },
                                 500,
                             ),
                         )
@@ -435,7 +429,10 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {"error": "Failed to create a default tab for import."},
+                            {
+                                "error":
+                                "Failed to create a default tab for import."
+                            },
                             500,
                         ),
                     )
@@ -448,13 +445,16 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({"error": "Failed to determine a target tab for import."}, 500),
+            ({
+                "error": "Failed to determine a target tab for import."
+            }, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
+                               affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -485,9 +485,13 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except SafeET.ParseError as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
+        logger.error("OPML import failed: Malformed XML. Error: %s",
+                     e,
+                     exc_info=True)
         return None, (
-            {"error": "Malformed OPML file. Please check the file format."},
+            {
+                "error": "Malformed OPML file. Please check the file format."
+            },
             400,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -497,7 +501,10 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {"error": "Could not parse OPML file. Please check the file format."},
+            {
+                "error":
+                "Could not parse OPML file. Please check the file format."
+            },
             400,
         )
 
@@ -520,13 +527,13 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
-                )
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i + 1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
+                                                                    1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -556,7 +563,9 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {"error": "Database error during final feed import step."},
+            {
+                "error": "Database error during final feed import step."
+            },
             500,
         )
 
@@ -622,8 +631,7 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list
-    )
+        state.newly_added_feeds_list)
     if not success:
         return None, error_resp
 
@@ -639,7 +647,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     )
 
     if not opml_body.findall("outline") and not state.newly_added_feeds_list:
-        logger.info("OPML import: No <outline> elements found in the OPML body.")
+        logger.info(
+            "OPML import: No <outline> elements found in the OPML body.")
         result = {
             "message": "No feed entries or folders found in the OPML file.",
             "imported_count": 0,
@@ -656,13 +665,19 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message":
+        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count": imported_final_count,
-        "skipped_count": skipped_final_count,
-        "tab_id": top_level_target_tab_id,
-        "tab_name": top_level_target_tab_name,
-        "affected_tab_ids": list(state.affected_tab_ids_set),
+        "imported_count":
+        imported_final_count,
+        "skipped_count":
+        skipped_final_count,
+        "tab_id":
+        top_level_target_tab_id,
+        "tab_name":
+        top_level_target_tab_name,
+        "affected_tab_ids":
+        list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -736,7 +751,8 @@ def _validate_xml_safety(content):
             forbid_external=True,
         )
     except (DTDForbidden, EntitiesForbidden, ExternalReferenceForbidden) as e:
-        logger.error("XML Security Violation detected: %s", _sanitize_for_log(str(e)))
+        logger.error("XML Security Violation detected: %s",
+                     _sanitize_for_log(str(e)))
         return False
     except (SAXParseException, UnicodeError) as e:
         # SECURITY HARDENING: Fail closed on malformed XML.
@@ -784,7 +800,8 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
+                parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -844,14 +861,8 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_reserved
-        or ip.is_multicast
-        or ip.is_unspecified
-    )
+    return not (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -882,9 +893,8 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection(
-            (self.safe_ip, self.port), self.timeout, self.source_address
-        )
+        self.sock = socket.create_connection((self.safe_ip, self.port),
+                                             self.timeout, self.source_address)
 
         if self._tunnel_host:
             self._tunnel()
@@ -920,9 +930,8 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection(
-            (self.safe_ip, self.port), self.timeout, self.source_address
-        )
+        self.sock = socket.create_connection((self.safe_ip, self.port),
+                                             self.timeout, self.source_address)
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -986,15 +995,15 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning(
-                "Blocked unsafe redirect to: %s", _sanitize_for_log(absolute_newurl)
-            )
-            raise urllib.error.HTTPError(
-                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
-            )
+            logger.warning("Blocked unsafe redirect to: %s",
+                           _sanitize_for_log(absolute_newurl))
+            raise urllib.error.HTTPError(absolute_newurl, code,
+                                         "Blocked unsafe redirect", headers,
+                                         fp)
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers,
+                                           absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1023,9 +1032,8 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception(
-            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
-        )
+        logger.exception("Error in fetch thread for feed %s",
+                         _sanitize_for_log(feed_url))
         return None
 
 
@@ -1104,9 +1112,8 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(
-            http_handler, https_handler, redirect_handler
-        )
+        opener = urllib.request.build_opener(http_handler, https_handler,
+                                             redirect_handler)
 
         req = urllib.request.Request(
             feed_url,
@@ -1161,7 +1168,8 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s", safe_log_url)
+            logger.warning("Feed rejected due to security violation: %s",
+                           safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1169,7 +1177,8 @@ def fetch_feed(feed_url):
         if parsed_feed.bozo:
             # Check for bozo_exception and sanitize it (it can contain malicious input)
             bozo_exc = parsed_feed.get("bozo_exception")
-            safe_exc_msg = _sanitize_for_log(str(bozo_exc)) if bozo_exc else "Unknown"
+            safe_exc_msg = _sanitize_for_log(
+                str(bozo_exc)) if bozo_exc else "Unknown"
             logger.warning("Feed parsing warning: %s", safe_exc_msg)
 
         return parsed_feed
@@ -1225,11 +1234,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (
-        db.session.query(FeedItem.id, FeedItem.guid, FeedItem.link, FeedItem.title)
-        .filter_by(feed_id=feed_db_obj.id)
-        .all()
-    )
+    items_tuple = (db.session.query(
+        FeedItem.id, FeedItem.guid, FeedItem.link,
+        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1256,9 +1263,8 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning(
-            "Failed to sort entries for feed %s", _sanitize_for_log(feed_db_obj.name)
-        )
+        logger.warning("Failed to sort entries for feed %s",
+                       _sanitize_for_log(feed_db_obj.name))
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1307,9 +1313,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-            db_guid,
-            batch_processed_guids,
-            feed_db_obj.name,
+                db_guid,
+                batch_processed_guids,
+                feed_db_obj.name,
         ):
             continue
 
@@ -1323,13 +1329,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            )
-        )
+            ))
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
+                          entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1355,9 +1361,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_li
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
-            updates, synchronize_session=False
-        )
+        db.session.query(FeedItem).filter(
+            FeedItem.id == existing_item_data.id).update(
+                updates, synchronize_session=False)
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1438,9 +1444,8 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug(
-                "Individually added item: %s", _sanitize_for_log(item.title[:50])
-            )
+            logger.debug("Individually added item: %s",
+                         _sanitize_for_log(item.title[:50]))
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1492,18 +1497,12 @@ def _enforce_feed_limit(feed_db_obj):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    ids_to_evict_rows = (
-        db.session.query(FeedItem.id)
-        .filter_by(feed_id=feed_db_obj.id)
-        .order_by(
+    ids_to_evict_rows = (db.session.query(
+        FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
             FeedItem.published_time.desc().nullslast(),
             FeedItem.fetched_time.desc().nullslast(),
             FeedItem.id.desc(),
-        )
-        .offset(MAX_ITEMS_PER_FEED)
-        .limit(EVICTION_LIMIT_PER_RUN)
-        .all()
-    )
+    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN).all())
 
     if not ids_to_evict_rows:
         return
@@ -1514,12 +1513,9 @@ def _enforce_feed_limit(feed_db_obj):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i : i + chunk_size]
-        deleted_count += (
-            db.session.query(FeedItem)
-            .filter(FeedItem.id.in_(chunk))
-            .delete(synchronize_session=False)
-        )
+        chunk = ids_to_evict[i:i + chunk_size]
+        deleted_count += (db.session.query(FeedItem).filter(
+            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
 
     if deleted_count > 0:
         logger.info(
@@ -1537,21 +1533,26 @@ def _enforce_feed_limit(feed_db_obj):
             )
 
 
-def _commit_metadata(feed_db_obj):
-    """Commits metadata and existing item updates immediately.
-
-    This ensures they are preserved even if the batch insert of new items fails later.
-    """
+def _commit_with_rollback(error_msg, feed_name):
+    """Helper to safely commit the db session with rollback on failure."""
     try:
         db.session.commit()
         return True
     except sqlalchemy.exc.SQLAlchemyError:
         db.session.rollback()
-        logger.exception(
-            "Error committing metadata/existing items for feed %s",
-            _sanitize_for_log(feed_db_obj.name),
-        )
+        logger.exception(error_msg, _sanitize_for_log(feed_name))
         return False
+
+
+def _commit_metadata(feed_db_obj):
+    """Commits metadata and existing item updates immediately.
+
+    This ensures they are preserved even if the batch insert of new items fails later.
+    """
+    return _commit_with_rollback(
+        "Error committing metadata/existing items for feed %s",
+        feed_db_obj.name
+    )
 
 
 def _update_timestamp_no_new_items(feed_db_obj):
@@ -1559,14 +1560,10 @@ def _update_timestamp_no_new_items(feed_db_obj):
     # last_updated_time is usually updated on successful commit of items,
     # or here if there were no items but fetch succeeded.
     feed_db_obj.last_updated_time = datetime.datetime.now(timezone.utc)
-    try:
-        db.session.commit()
-    except sqlalchemy.exc.SQLAlchemyError:
-        db.session.rollback()
-        logger.exception(
-            "Error committing feed update (no new items) for %s",
-            _sanitize_for_log(feed_db_obj.name),
-        )
+    _commit_with_rollback(
+        "Error committing feed update (no new items) for %s",
+        feed_db_obj.name
+    )
 
 
 def process_feed_entries(feed_db_obj, parsed_feed):
@@ -1640,15 +1637,19 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).", total_feeds)
+    logger.info("Starting update process for %d feeds (Parallelized).",
+                total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
-    actual_workers = min(MAX_CONCURRENT_FETCHES, total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
+    actual_workers = min(MAX_CONCURRENT_FETCHES,
+                         total_feeds) if all_feeds else 1
+    with concurrent.futures.ThreadPoolExecutor(
+            max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed
+            for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1662,8 +1663,7 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed
-                )
+                    feed_obj, parsed_feed)
                 if success:
                     successful_count += 1
                     total_new_items += new_items

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -111,8 +111,9 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(processed_count, total_count,
-                                     last_announced_percent):
+def _calculate_and_announce_progress(
+    processed_count, total_count, last_announced_percent
+):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -124,10 +125,12 @@ def _calculate_and_announce_progress(processed_count, total_count,
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (processed_count == 0 or processed_count >= total_count
-                       or (current_percent != last_announced_percent
-                           and current_percent % 5 == 0)
-                       or processed_count % 20 == 0)
+    should_announce = (
+        processed_count == 0
+        or processed_count >= total_count
+        or (current_percent != last_announced_percent and current_percent % 5 == 0)
+        or processed_count % 20 == 0
+    )
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -233,10 +236,10 @@ def _process_folder_node(
 
     if element_name and child_outlines:
         try:
-            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
-                element_name)
-            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
-                                nested_tab_name))
+            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(element_name)
+            state.stack.append(
+                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
+            )
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -246,7 +249,8 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
+        )
         return
 
     state.skipped_count += 1
@@ -287,11 +291,13 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [(
-        list(reversed(initial_outline_elements)),
-        top_level_tab_id,
-        top_level_tab_name,
-    )]
+    stack = [
+        (
+            list(reversed(initial_outline_elements)),
+            top_level_tab_id,
+            top_level_tab_name,
+        )
+    ]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -309,8 +315,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines,
-                last_announced_percent)
+                processed_outline_count, total_outlines, last_announced_percent
+            )
 
             _process_single_outline_node(
                 outline_element,
@@ -364,13 +370,15 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation).first()
+                name=default_tab_name_for_creation
+            ).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0)
+                    name=default_tab_name_for_creation, order=0
+                )
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -395,7 +403,8 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation).first()
+                        name=default_tab_name_for_creation
+                    ).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -411,10 +420,7 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {
-                                    "error":
-                                    "Failed to create a default tab for import."
-                                },
+                                {"error": "Failed to create a default tab for import."},
                                 500,
                             ),
                         )
@@ -429,10 +435,7 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {
-                                "error":
-                                "Failed to create a default tab for import."
-                            },
+                            {"error": "Failed to create a default tab for import."},
                             500,
                         ),
                     )
@@ -445,16 +448,13 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({
-                "error": "Failed to determine a target tab for import."
-            }, 500),
+            ({"error": "Failed to determine a target tab for import."}, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
-                               affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -485,13 +485,9 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except SafeET.ParseError as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s",
-                     e,
-                     exc_info=True)
+        logger.error("OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
         return None, (
-            {
-                "error": "Malformed OPML file. Please check the file format."
-            },
+            {"error": "Malformed OPML file. Please check the file format."},
             400,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -501,10 +497,7 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {
-                "error":
-                "Could not parse OPML file. Please check the file format."
-            },
+            {"error": "Could not parse OPML file. Please check the file format."},
             400,
         )
 
@@ -527,13 +520,13 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
+                )
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
-                                                                    1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - 1 or (i + 1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -563,9 +556,7 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {
-                "error": "Database error during final feed import step."
-            },
+            {"error": "Database error during final feed import step."},
             500,
         )
 
@@ -631,7 +622,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list)
+        state.newly_added_feeds_list
+    )
     if not success:
         return None, error_resp
 
@@ -647,8 +639,7 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     )
 
     if not opml_body.findall("outline") and not state.newly_added_feeds_list:
-        logger.info(
-            "OPML import: No <outline> elements found in the OPML body.")
+        logger.info("OPML import: No <outline> elements found in the OPML body.")
         result = {
             "message": "No feed entries or folders found in the OPML file.",
             "imported_count": 0,
@@ -665,19 +656,13 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message":
-        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count":
-        imported_final_count,
-        "skipped_count":
-        skipped_final_count,
-        "tab_id":
-        top_level_target_tab_id,
-        "tab_name":
-        top_level_target_tab_name,
-        "affected_tab_ids":
-        list(state.affected_tab_ids_set),
+        "imported_count": imported_final_count,
+        "skipped_count": skipped_final_count,
+        "tab_id": top_level_target_tab_id,
+        "tab_name": top_level_target_tab_name,
+        "affected_tab_ids": list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -751,8 +736,7 @@ def _validate_xml_safety(content):
             forbid_external=True,
         )
     except (DTDForbidden, EntitiesForbidden, ExternalReferenceForbidden) as e:
-        logger.error("XML Security Violation detected: %s",
-                     _sanitize_for_log(str(e)))
+        logger.error("XML Security Violation detected: %s", _sanitize_for_log(str(e)))
         return False
     except (SAXParseException, UnicodeError) as e:
         # SECURITY HARDENING: Fail closed on malformed XML.
@@ -800,8 +784,7 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
-                parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -861,8 +844,14 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (ip.is_private or ip.is_loopback or ip.is_link_local
-                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -893,8 +882,9 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
         if self._tunnel_host:
             self._tunnel()
@@ -930,8 +920,9 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -995,15 +986,15 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning("Blocked unsafe redirect to: %s",
-                           _sanitize_for_log(absolute_newurl))
-            raise urllib.error.HTTPError(absolute_newurl, code,
-                                         "Blocked unsafe redirect", headers,
-                                         fp)
+            logger.warning(
+                "Blocked unsafe redirect to: %s", _sanitize_for_log(absolute_newurl)
+            )
+            raise urllib.error.HTTPError(
+                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
+            )
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers,
-                                           absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1032,8 +1023,9 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception("Error in fetch thread for feed %s",
-                         _sanitize_for_log(feed_url))
+        logger.exception(
+            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
+        )
         return None
 
 
@@ -1112,8 +1104,9 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(http_handler, https_handler,
-                                             redirect_handler)
+        opener = urllib.request.build_opener(
+            http_handler, https_handler, redirect_handler
+        )
 
         req = urllib.request.Request(
             feed_url,
@@ -1168,8 +1161,7 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s",
-                           safe_log_url)
+            logger.warning("Feed rejected due to security violation: %s", safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1177,8 +1169,7 @@ def fetch_feed(feed_url):
         if parsed_feed.bozo:
             # Check for bozo_exception and sanitize it (it can contain malicious input)
             bozo_exc = parsed_feed.get("bozo_exception")
-            safe_exc_msg = _sanitize_for_log(
-                str(bozo_exc)) if bozo_exc else "Unknown"
+            safe_exc_msg = _sanitize_for_log(str(bozo_exc)) if bozo_exc else "Unknown"
             logger.warning("Feed parsing warning: %s", safe_exc_msg)
 
         return parsed_feed
@@ -1234,9 +1225,11 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (db.session.query(
-        FeedItem.id, FeedItem.guid, FeedItem.link,
-        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
+    items_tuple = (
+        db.session.query(FeedItem.id, FeedItem.guid, FeedItem.link, FeedItem.title)
+        .filter_by(feed_id=feed_db_obj.id)
+        .all()
+    )
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1263,8 +1256,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning("Failed to sort entries for feed %s",
-                       _sanitize_for_log(feed_db_obj.name))
+        logger.warning(
+            "Failed to sort entries for feed %s", _sanitize_for_log(feed_db_obj.name)
+        )
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1313,9 +1307,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-                db_guid,
-                batch_processed_guids,
-                feed_db_obj.name,
+            db_guid,
+            batch_processed_guids,
+            feed_db_obj.name,
         ):
             continue
 
@@ -1329,13 +1323,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            ))
+            )
+        )
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
-                          entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1361,9 +1355,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(
-            FeedItem.id == existing_item_data.id).update(
-                updates, synchronize_session=False)
+        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
+            updates, synchronize_session=False
+        )
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1444,8 +1438,9 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug("Individually added item: %s",
-                         _sanitize_for_log(item.title[:50]))
+            logger.debug(
+                "Individually added item: %s", _sanitize_for_log(item.title[:50])
+            )
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1497,12 +1492,18 @@ def _enforce_feed_limit(feed_db_obj):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    ids_to_evict_rows = (db.session.query(
-        FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
+    ids_to_evict_rows = (
+        db.session.query(FeedItem.id)
+        .filter_by(feed_id=feed_db_obj.id)
+        .order_by(
             FeedItem.published_time.desc().nullslast(),
             FeedItem.fetched_time.desc().nullslast(),
             FeedItem.id.desc(),
-    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN).all())
+        )
+        .offset(MAX_ITEMS_PER_FEED)
+        .limit(EVICTION_LIMIT_PER_RUN)
+        .all()
+    )
 
     if not ids_to_evict_rows:
         return
@@ -1513,9 +1514,12 @@ def _enforce_feed_limit(feed_db_obj):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i:i + chunk_size]
-        deleted_count += (db.session.query(FeedItem).filter(
-            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
+        chunk = ids_to_evict[i : i + chunk_size]
+        deleted_count += (
+            db.session.query(FeedItem)
+            .filter(FeedItem.id.in_(chunk))
+            .delete(synchronize_session=False)
+        )
 
     if deleted_count > 0:
         logger.info(
@@ -1550,8 +1554,7 @@ def _commit_metadata(feed_db_obj):
     This ensures they are preserved even if the batch insert of new items fails later.
     """
     return _commit_with_rollback(
-        "Error committing metadata/existing items for feed %s",
-        feed_db_obj.name
+        "Error committing metadata/existing items for feed %s", feed_db_obj.name
     )
 
 
@@ -1561,8 +1564,7 @@ def _update_timestamp_no_new_items(feed_db_obj):
     # or here if there were no items but fetch succeeded.
     feed_db_obj.last_updated_time = datetime.datetime.now(timezone.utc)
     _commit_with_rollback(
-        "Error committing feed update (no new items) for %s",
-        feed_db_obj.name
+        "Error committing feed update (no new items) for %s", feed_db_obj.name
     )
 
 
@@ -1637,19 +1639,15 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).",
-                total_feeds)
+    logger.info("Starting update process for %d feeds (Parallelized).", total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
-    actual_workers = min(MAX_CONCURRENT_FETCHES,
-                         total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(
-            max_workers=actual_workers) as executor:
+    actual_workers = min(MAX_CONCURRENT_FETCHES, total_feeds) if all_feeds else 1
+    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed
-            for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1663,7 +1661,8 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed)
+                    feed_obj, parsed_feed
+                )
                 if success:
                     successful_count += 1
                     total_new_items += new_items

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -1533,6 +1533,38 @@ def _enforce_feed_limit(feed_db_obj):
             )
 
 
+def _commit_metadata(feed_db_obj):
+    """Commits metadata and existing item updates immediately.
+
+    This ensures they are preserved even if the batch insert of new items fails later.
+    """
+    try:
+        db.session.commit()
+        return True
+    except sqlalchemy.exc.SQLAlchemyError:
+        db.session.rollback()
+        logger.exception(
+            "Error committing metadata/existing items for feed %s",
+            _sanitize_for_log(feed_db_obj.name),
+        )
+        return False
+
+
+def _update_timestamp_no_new_items(feed_db_obj):
+    """Updates the feed timestamp when there are no new items."""
+    # last_updated_time is usually updated on successful commit of items,
+    # or here if there were no items but fetch succeeded.
+    feed_db_obj.last_updated_time = datetime.datetime.now(timezone.utc)
+    try:
+        db.session.commit()
+    except sqlalchemy.exc.SQLAlchemyError:
+        db.session.rollback()
+        logger.exception(
+            "Error committing feed update (no new items) for %s",
+            _sanitize_for_log(feed_db_obj.name),
+        )
+
+
 def process_feed_entries(feed_db_obj, parsed_feed):
     """Processes entries from a parsed feed and adds new items to the database.
 
@@ -1554,33 +1586,14 @@ def process_feed_entries(feed_db_obj, parsed_feed):
     _update_feed_metadata(feed_db_obj, parsed_feed)
     items_to_add = _collect_new_items(feed_db_obj, parsed_feed)
 
-    # Commit metadata and existing item updates immediately.
-    # This ensures they are preserved even if the batch insert of new items fails later.
-    try:
-        db.session.commit()
-    except sqlalchemy.exc.SQLAlchemyError:
-        db.session.rollback()
-        logger.exception(
-            "Error committing metadata/existing items for feed %s",
-            _sanitize_for_log(feed_db_obj.name),
-        )
+    if not _commit_metadata(feed_db_obj):
         # It's safer to stop processing this feed to avoid potential inconsistencies
         # if the metadata/update commit failed.
         return 0
 
     if not items_to_add:
         # If no new items, we are done.
-        # last_updated_time is usually updated on successful commit of items,
-        # or here if there were no items but fetch succeeded.
-        feed_db_obj.last_updated_time = datetime.datetime.now(timezone.utc)
-        try:
-            db.session.commit()
-        except sqlalchemy.exc.SQLAlchemyError:
-            db.session.rollback()
-            logger.exception(
-                "Error committing feed update (no new items) for %s",
-                _sanitize_for_log(feed_db_obj.name),
-            )
+        _update_timestamp_no_new_items(feed_db_obj)
         return 0
 
     committed_items_count = _save_items_to_db(feed_db_obj, items_to_add)

--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -111,8 +111,9 @@ def is_valid_feed_url(url):
     return bool(validate_link_structure(url))
 
 
-def _calculate_and_announce_progress(processed_count, total_count,
-                                     last_announced_percent):
+def _calculate_and_announce_progress(
+    processed_count, total_count, last_announced_percent
+):
     """Calculates progress and announces it if significant change occurred."""
     if total_count > 0:
         # Cap progress value, as processed_count can exceed total_count.
@@ -124,10 +125,12 @@ def _calculate_and_announce_progress(processed_count, total_count,
         progress_val = OPML_IMPORT_PROCESSING_WEIGHT
 
     current_percent = progress_val
-    should_announce = (processed_count == 0 or processed_count >= total_count
-                       or (current_percent != last_announced_percent
-                           and current_percent % 5 == 0)
-                       or processed_count % 20 == 0)
+    should_announce = (
+        processed_count == 0
+        or processed_count >= total_count
+        or (current_percent != last_announced_percent and current_percent % 5 == 0)
+        or processed_count % 20 == 0
+    )
 
     if should_announce:
         status_msg = f"Processing OPML... ({processed_count} outlines analyzed)"
@@ -233,10 +236,10 @@ def _process_folder_node(
 
     if element_name and child_outlines:
         try:
-            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(
-                element_name)
-            state.stack.append((list(reversed(child_outlines)), nested_tab_id,
-                                nested_tab_name))
+            nested_tab_id, nested_tab_name = _get_or_create_nested_tab(element_name)
+            state.stack.append(
+                (list(reversed(child_outlines)), nested_tab_id, nested_tab_name)
+            )
         except sqlalchemy.exc.SQLAlchemyError:
             logger.exception(
                 "OPML import: DB error creating tab for folder '%s'. Skipping folder.",
@@ -246,7 +249,8 @@ def _process_folder_node(
 
     if not element_name and child_outlines:
         state.stack.append(
-            (list(reversed(child_outlines)), current_tab_id, current_tab_name))
+            (list(reversed(child_outlines)), current_tab_id, current_tab_name)
+        )
         return
 
     state.skipped_count += 1
@@ -287,11 +291,13 @@ def _process_opml_outlines_iterative(
 ):
     """Iteratively processes OPML outline elements with weighted progress updates."""
     # Phase 1: Processing (0-50%)
-    stack = [(
-        list(reversed(initial_outline_elements)),
-        top_level_tab_id,
-        top_level_tab_name,
-    )]
+    stack = [
+        (
+            list(reversed(initial_outline_elements)),
+            top_level_tab_id,
+            top_level_tab_name,
+        )
+    ]
     state = OpmlImportState(
         stack=stack,
         all_existing_feed_urls_set=all_existing_feed_urls_set,
@@ -309,8 +315,8 @@ def _process_opml_outlines_iterative(
             processed_outline_count += 1
 
             last_announced_percent = _calculate_and_announce_progress(
-                processed_outline_count, total_outlines,
-                last_announced_percent)
+                processed_outline_count, total_outlines, last_announced_percent
+            )
 
             _process_single_outline_node(
                 outline_element,
@@ -364,13 +370,15 @@ def _determine_target_tab(requested_tab_id_str):
             )
             default_tab_name_for_creation = DEFAULT_OPML_IMPORT_TAB_NAME
             temp_tab_check = Tab.query.filter_by(
-                name=default_tab_name_for_creation).first()
+                name=default_tab_name_for_creation
+            ).first()
             if temp_tab_check:
                 target_tab_id = temp_tab_check.id
                 target_tab_name = temp_tab_check.name
             else:
                 newly_created_default_tab = Tab(
-                    name=default_tab_name_for_creation, order=0)
+                    name=default_tab_name_for_creation, order=0
+                )
                 db.session.add(newly_created_default_tab)
                 try:
                     # Since this is the start of the import, we can safely commit the new tab
@@ -395,7 +403,8 @@ def _determine_target_tab(requested_tab_id_str):
                     )
                     # Another process likely created it. Fetch it.
                     refetched_tab = Tab.query.filter_by(
-                        name=default_tab_name_for_creation).first()
+                        name=default_tab_name_for_creation
+                    ).first()
                     if refetched_tab:
                         target_tab_id = refetched_tab.id
                         target_tab_name = refetched_tab.name
@@ -411,10 +420,7 @@ def _determine_target_tab(requested_tab_id_str):
                             None,
                             False,
                             (
-                                {
-                                    "error":
-                                    "Failed to create a default tab for import."
-                                },
+                                {"error": "Failed to create a default tab for import."},
                                 500,
                             ),
                         )
@@ -429,10 +435,7 @@ def _determine_target_tab(requested_tab_id_str):
                         None,
                         False,
                         (
-                            {
-                                "error":
-                                "Failed to create a default tab for import."
-                            },
+                            {"error": "Failed to create a default tab for import."},
                             500,
                         ),
                     )
@@ -445,16 +448,13 @@ def _determine_target_tab(requested_tab_id_str):
             None,
             None,
             False,
-            ({
-                "error": "Failed to determine a target tab for import."
-            }, 500),
+            ({"error": "Failed to determine a target tab for import."}, 500),
         )
 
     return target_tab_id, target_tab_name, was_created, None
 
 
-def _cleanup_empty_default_tab(was_created, tab_id, tab_name,
-                               affected_tab_ids):
+def _cleanup_empty_default_tab(was_created, tab_id, tab_name, affected_tab_ids):
     """Cleans up the default tab if it was created for this import but remains empty."""
     if was_created and tab_id not in affected_tab_ids:
         try:
@@ -485,13 +485,9 @@ def _parse_opml_root(opml_stream):
         root = tree.getroot()
         return root, None
     except SafeET.ParseError as e:
-        logger.error("OPML import failed: Malformed XML. Error: %s",
-                     e,
-                     exc_info=True)
+        logger.error("OPML import failed: Malformed XML. Error: %s", e, exc_info=True)
         return None, (
-            {
-                "error": "Malformed OPML file. Please check the file format."
-            },
+            {"error": "Malformed OPML file. Please check the file format."},
             400,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -501,10 +497,7 @@ def _parse_opml_root(opml_stream):
             exc_info=True,
         )
         return None, (
-            {
-                "error":
-                "Could not parse OPML file. Please check the file format."
-            },
+            {"error": "Could not parse OPML file. Please check the file format."},
             400,
         )
 
@@ -527,13 +520,13 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
             # Phase 2 value: Processing Weight to 100
             if total_to_fetch > 0:
                 progress_val = OPML_IMPORT_PROCESSING_WEIGHT + (
-                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch)
+                    (i + 1) * OPML_IMPORT_FETCHING_WEIGHT // total_to_fetch
+                )
             else:
                 progress_val = 100
 
             # Only announce if significant progress or first/last
-            should_announce = i == 0 or i == total_to_fetch - 1 or (i +
-                                                                    1) % 5 == 0
+            should_announce = i == 0 or i == total_to_fetch - 1 or (i + 1) % 5 == 0
 
             if should_announce:
                 event_data = {
@@ -563,9 +556,7 @@ def _batch_commit_and_fetch_new_feeds(newly_added_feeds_list):
         db.session.rollback()
         logger.exception("OPML import: Database commit failed for new feeds")
         return False, (
-            {
-                "error": "Database error during final feed import step."
-            },
+            {"error": "Database error during final feed import step."},
             500,
         )
 
@@ -631,7 +622,8 @@ def import_opml(opml_file_stream, requested_tab_id_str):
 
     # Batch commit and fetch
     success, error_resp = _batch_commit_and_fetch_new_feeds(
-        state.newly_added_feeds_list)
+        state.newly_added_feeds_list
+    )
     if not success:
         return None, error_resp
 
@@ -647,8 +639,7 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     )
 
     if not opml_body.findall("outline") and not state.newly_added_feeds_list:
-        logger.info(
-            "OPML import: No <outline> elements found in the OPML body.")
+        logger.info("OPML import: No <outline> elements found in the OPML body.")
         result = {
             "message": "No feed entries or folders found in the OPML file.",
             "imported_count": 0,
@@ -665,19 +656,13 @@ def import_opml(opml_file_stream, requested_tab_id_str):
     skipped_final_count = state.skipped_count
 
     result = {
-        "message":
-        f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
+        "message": f"{imported_final_count} feeds imported. {skipped_final_count} skipped. "
         f"Tab: {top_level_target_tab_name}.",
-        "imported_count":
-        imported_final_count,
-        "skipped_count":
-        skipped_final_count,
-        "tab_id":
-        top_level_target_tab_id,
-        "tab_name":
-        top_level_target_tab_name,
-        "affected_tab_ids":
-        list(state.affected_tab_ids_set),
+        "imported_count": imported_final_count,
+        "skipped_count": skipped_final_count,
+        "tab_id": top_level_target_tab_id,
+        "tab_name": top_level_target_tab_name,
+        "affected_tab_ids": list(state.affected_tab_ids_set),
     }
 
     # Final 'complete' message for SSE
@@ -751,8 +736,7 @@ def _validate_xml_safety(content):
             forbid_external=True,
         )
     except (DTDForbidden, EntitiesForbidden, ExternalReferenceForbidden) as e:
-        logger.error("XML Security Violation detected: %s",
-                     _sanitize_for_log(str(e)))
+        logger.error("XML Security Violation detected: %s", _sanitize_for_log(str(e)))
         return False
     except (SAXParseException, UnicodeError) as e:
         # SECURITY HARDENING: Fail closed on malformed XML.
@@ -800,8 +784,7 @@ def parse_published_time(entry):
             parsed_dt = None
 
     if isinstance(parsed_dt, datetime.datetime):
-        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(
-                parsed_dt) is None:
+        if parsed_dt.tzinfo is None or parsed_dt.tzinfo.utcoffset(parsed_dt) is None:
             return parsed_dt.replace(tzinfo=timezone.utc)
         return parsed_dt.astimezone(timezone.utc)
 
@@ -861,8 +844,14 @@ def validate_and_resolve_url(url):
 
 def _is_safe_ip(ip):
     """Checks if an IP address is safe (not private, loopback, etc.)."""
-    return not (ip.is_private or ip.is_loopback or ip.is_link_local
-                or ip.is_reserved or ip.is_multicast or ip.is_unspecified)
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
 
 
 class SafeHTTPSConnection(http.client.HTTPSConnection):
@@ -893,8 +882,9 @@ class SafeHTTPSConnection(http.client.HTTPSConnection):
         # Logic adapted from http.client.HTTPSConnection.connect
 
         # 1. Establish TCP connection to the SAFE IP
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
         if self._tunnel_host:
             self._tunnel()
@@ -930,8 +920,9 @@ class SafeHTTPConnection(http.client.HTTPConnection):
 
     def connect(self):
         # Override connect to force connection to self.safe_ip
-        self.sock = socket.create_connection((self.safe_ip, self.port),
-                                             self.timeout, self.source_address)
+        self.sock = socket.create_connection(
+            (self.safe_ip, self.port), self.timeout, self.source_address
+        )
 
 
 class SafeHTTPHandler(urllib.request.HTTPHandler):
@@ -995,15 +986,15 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         # Resolve and validate the NEW url
         safe_ip, _ = validate_and_resolve_url(absolute_newurl)
         if not safe_ip:
-            logger.warning("Blocked unsafe redirect to: %s",
-                           _sanitize_for_log(absolute_newurl))
-            raise urllib.error.HTTPError(absolute_newurl, code,
-                                         "Blocked unsafe redirect", headers,
-                                         fp)
+            logger.warning(
+                "Blocked unsafe redirect to: %s", _sanitize_for_log(absolute_newurl)
+            )
+            raise urllib.error.HTTPError(
+                absolute_newurl, code, "Blocked unsafe redirect", headers, fp
+            )
 
         # Create the new request
-        new_req = super().redirect_request(req, fp, code, msg, headers,
-                                           absolute_newurl)
+        new_req = super().redirect_request(req, fp, code, msg, headers, absolute_newurl)
 
         # PIN THE IP: Attach the resolved safe_ip to the new request
         # This allows SafeHTTPSHandler (and HTTP logic) to use the validated IP
@@ -1032,8 +1023,9 @@ def _fetch_feed_content(feed_url):
         parsed_feed = fetch_feed(feed_url)
         return parsed_feed
     except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception("Error in fetch thread for feed %s",
-                         _sanitize_for_log(feed_url))
+        logger.exception(
+            "Error in fetch thread for feed %s", _sanitize_for_log(feed_url)
+        )
         return None
 
 
@@ -1112,8 +1104,9 @@ def fetch_feed(feed_url):
         redirect_handler = SafeRedirectHandler()
 
         # Build opener with all handlers
-        opener = urllib.request.build_opener(http_handler, https_handler,
-                                             redirect_handler)
+        opener = urllib.request.build_opener(
+            http_handler, https_handler, redirect_handler
+        )
 
         req = urllib.request.Request(
             feed_url,
@@ -1168,8 +1161,7 @@ def fetch_feed(feed_url):
         if not _validate_xml_safety(content):
             # Sanitize URL for logging to prevent log injection
             safe_log_url = _sanitize_for_log(feed_url)
-            logger.warning("Feed rejected due to security violation: %s",
-                           safe_log_url)
+            logger.warning("Feed rejected due to security violation: %s", safe_log_url)
             return None
 
         parsed_feed = feedparser.parse(content)
@@ -1177,8 +1169,7 @@ def fetch_feed(feed_url):
         if parsed_feed.bozo:
             # Check for bozo_exception and sanitize it (it can contain malicious input)
             bozo_exc = parsed_feed.get("bozo_exception")
-            safe_exc_msg = _sanitize_for_log(
-                str(bozo_exc)) if bozo_exc else "Unknown"
+            safe_exc_msg = _sanitize_for_log(str(bozo_exc)) if bozo_exc else "Unknown"
             logger.warning("Feed parsing warning: %s", safe_exc_msg)
 
         return parsed_feed
@@ -1234,9 +1225,11 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
     # Optimization: Query only necessary columns to avoid loading full objects
     # item[1] is guid, item[2] is link, item[3] is title
-    items_tuple = (db.session.query(
-        FeedItem.id, FeedItem.guid, FeedItem.link,
-        FeedItem.title).filter_by(feed_id=feed_db_obj.id).all())
+    items_tuple = (
+        db.session.query(FeedItem.id, FeedItem.guid, FeedItem.link, FeedItem.title)
+        .filter_by(feed_id=feed_db_obj.id)
+        .all()
+    )
 
     # Create lookup maps
     existing_items_by_guid = {it.guid: it for it in items_tuple if it.guid}
@@ -1263,8 +1256,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
         entries_with_dates.sort(key=lambda x: x[1], reverse=True)
     except Exception:  # pylint: disable=broad-exception-caught
         # If sorting fails, proceed with original order.
-        logger.warning("Failed to sort entries for feed %s",
-                       _sanitize_for_log(feed_db_obj.name))
+        logger.warning(
+            "Failed to sort entries for feed %s", _sanitize_for_log(feed_db_obj.name)
+        )
 
     for entry, parsed_published in entries_with_dates:
         raw_link = entry.get("link")
@@ -1313,9 +1307,9 @@ def _collect_new_items(feed_db_obj, parsed_feed):
 
         # Check batch duplicates
         if _is_batch_duplicate(
-                db_guid,
-                batch_processed_guids,
-                feed_db_obj.name,
+            db_guid,
+            batch_processed_guids,
+            feed_db_obj.name,
         ):
             continue
 
@@ -1329,13 +1323,13 @@ def _collect_new_items(feed_db_obj, parsed_feed):
                 link=entry_link,
                 published_time=parsed_published,
                 guid=db_guid,
-            ))
+            )
+        )
 
     return items_to_add
 
 
-def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
-                          entry_link):
+def _update_existing_item(feed_db_obj, existing_item_data, entry_title, entry_link):
     """Updates an existing item if title or link changed.
 
     Args:
@@ -1361,9 +1355,9 @@ def _update_existing_item(feed_db_obj, existing_item_data, entry_title,
             _sanitize_for_log(existing_title),
             _sanitize_for_log(feed_db_obj.name),
         )
-        db.session.query(FeedItem).filter(
-            FeedItem.id == existing_item_data.id).update(
-                updates, synchronize_session=False)
+        db.session.query(FeedItem).filter(FeedItem.id == existing_item_data.id).update(
+            updates, synchronize_session=False
+        )
 
 
 def _is_batch_duplicate(db_guid, batch_guids, feed_name):
@@ -1444,8 +1438,9 @@ def _save_items_individually(feed_db_obj, items_to_add):
             db.session.add(item)
             db.session.commit()
             count += 1
-            logger.debug("Individually added item: %s",
-                         _sanitize_for_log(item.title[:50]))
+            logger.debug(
+                "Individually added item: %s", _sanitize_for_log(item.title[:50])
+            )
         except IntegrityError as ie:
             db.session.rollback()
             logger.error(
@@ -1497,12 +1492,18 @@ def _enforce_feed_limit(feed_db_obj):
     # 1. Provide a bounded result set, avoiding OOM on massive feeds.
     # 2. Avoid SQLite-specific LIMIT -1 behavior.
     # This means we only delete up to EVICTION_LIMIT_PER_RUN items per update, which acts as eventual consistency.
-    ids_to_evict_rows = (db.session.query(
-        FeedItem.id).filter_by(feed_id=feed_db_obj.id).order_by(
+    ids_to_evict_rows = (
+        db.session.query(FeedItem.id)
+        .filter_by(feed_id=feed_db_obj.id)
+        .order_by(
             FeedItem.published_time.desc().nullslast(),
             FeedItem.fetched_time.desc().nullslast(),
             FeedItem.id.desc(),
-    ).offset(MAX_ITEMS_PER_FEED).limit(EVICTION_LIMIT_PER_RUN).all())
+        )
+        .offset(MAX_ITEMS_PER_FEED)
+        .limit(EVICTION_LIMIT_PER_RUN)
+        .all()
+    )
 
     if not ids_to_evict_rows:
         return
@@ -1513,9 +1514,12 @@ def _enforce_feed_limit(feed_db_obj):
     chunk_size = DELETE_CHUNK_SIZE
     deleted_count = 0
     for i in range(0, len(ids_to_evict), chunk_size):
-        chunk = ids_to_evict[i:i + chunk_size]
-        deleted_count += (db.session.query(FeedItem).filter(
-            FeedItem.id.in_(chunk)).delete(synchronize_session=False))
+        chunk = ids_to_evict[i : i + chunk_size]
+        deleted_count += (
+            db.session.query(FeedItem)
+            .filter(FeedItem.id.in_(chunk))
+            .delete(synchronize_session=False)
+        )
 
     if deleted_count > 0:
         logger.info(
@@ -1636,19 +1640,15 @@ def update_all_feeds():
     total_new_items = 0
     affected_tab_ids = set()
 
-    logger.info("Starting update process for %d feeds (Parallelized).",
-                total_feeds)
+    logger.info("Starting update process for %d feeds (Parallelized).", total_feeds)
     announcer.announce(
         msg=f"data: {json.dumps({'type': 'progress', 'status': 'Starting feed refresh...', 'value': 0, 'max': total_feeds})}\n\n"
     )
 
-    actual_workers = min(MAX_CONCURRENT_FETCHES,
-                         total_feeds) if all_feeds else 1
-    with concurrent.futures.ThreadPoolExecutor(
-            max_workers=actual_workers) as executor:
+    actual_workers = min(MAX_CONCURRENT_FETCHES, total_feeds) if all_feeds else 1
+    with concurrent.futures.ThreadPoolExecutor(max_workers=actual_workers) as executor:
         future_to_feed = {
-            executor.submit(_fetch_feed_content, feed.url): feed
-            for feed in all_feeds
+            executor.submit(_fetch_feed_content, feed.url): feed for feed in all_feeds
         }
 
         for future in concurrent.futures.as_completed(future_to_feed):
@@ -1662,7 +1662,8 @@ def update_all_feeds():
             try:
                 parsed_feed = future.result()
                 success, new_items, tab_id = _process_fetch_result(
-                    feed_obj, parsed_feed)
+                    feed_obj, parsed_feed
+                )
                 if success:
                     successful_count += 1
                     total_new_items += new_items


### PR DESCRIPTION
🎯 What: Extracted DB commit and error handling try/except blocks from process_feed_entries into smaller private helper functions _commit_metadata and _update_timestamp_no_new_items.
💡 Why: Improves readability and maintainability by keeping process_feed_entries focused on core logic rather than boilerplate exception handling.
✅ Verification: Passes backend flake8 and python pytest test suite.
✨ Result: process_feed_entries is cleaner, shorter, and easier to follow without altering original application behavior.

---
*PR created automatically by Jules for task [3626483297546521406](https://jules.google.com/task/3626483297546521406) started by @sheepdestroyer*

## Summary by Sourcery

Refactor feed processing to delegate database commit and timestamp update responsibilities to dedicated helper functions, keeping process_feed_entries focused on its core logic.

Enhancements:
- Extract database commit handling for feed metadata and existing item updates into a dedicated _commit_metadata helper.
- Extract the no-new-items timestamp update and associated commit logic into a dedicated _update_timestamp_no_new_items helper to simplify process_feed_entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable feed updates with improved handling of partial failures and fewer duplicate items.
  * Better stability when feeds return no new items; timestamp and metadata persistence is more robust.
  * Improved deduplication for items missing IDs, reducing false-duplicate and legacy-link matches.

* **Chores**
  * Improved import progress and error reporting for feed imports.
  * Enhanced logging, parsing safety, and error handling around feed fetching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/SheepVibes/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->