### PR TITLE
🧹 Fix too-many-arguments warning in SafeRedirectHandler

### DIFF
--- a/backend/feed_service.py
+++ b/backend/feed_service.py
@@ -977,6 +977,7 @@ class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
     """
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         # Handle relative redirects by joining with original URL
         absolute_newurl = urljoin(req.full_url, newurl)
 


### PR DESCRIPTION
🎯 **What:** Suppressed `too-many-arguments` and `too-many-positional-arguments` pylint warnings in the `redirect_request` method of `SafeRedirectHandler`.
💡 **Why:** The method overrides the standard library's `urllib.request.HTTPRedirectHandler.redirect_request`, so the signature is dictated by the parent class. Attempting to reduce explicit parameters using `*args` would obscure the required inputs. Suppressing the linter warning is the safest and cleanest way to address the code health issue while preserving exact intended functionality.
✅ **Verification:** Verified that adding the suppression comment silences the pylint warnings for the file. Ran the backend test suite successfully (`pytest tests/`) to ensure no logical changes were introduced.
✨ **Result:** Improved maintainability by clearly indicating that the parameter count is an intentional override requirement, resolving the code health finding.

---
*PR created automatically by Jules for task [11482332213465878708](https://jules.google.com/task/11482332213465878708) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Add explicit pylint suppression for too-many-arguments and too-many-positional-arguments on SafeRedirectHandler.redirect_request to document and accept its inherited signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to the latest version.
  * Enhanced code quality tooling configuration to maintain code standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/SheepVibes/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->