### PR TITLE
fix: resolve port conflict and subpath routing for reverse proxy deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-08-05
 
+- **Fix: Remove non-portable host volume mount** (PR #500)
+  - Removed hardcoded host volume mount `Volume=/mnt/DATA/boy/prod/SheepVibes/frontend:/app/frontend:ro` from `pod/sheepvibes-app.container`.
+
 - **Fix: Frontend UX, Accessibility, and State Management** (PR #515)
   - **Utils**: Updated `throttle` trailing-edge execution with `try ... finally` to ensure `isThrottled = false` is always reset even if callback throws.
   - **Accessibility**: Added `role="tabpanel"` to `#feed-grid` container for complete WAI-ARIA tab semantics.

--- a/TODO.md
+++ b/TODO.md
@@ -139,3 +139,5 @@ This document outlines the steps to build the SheepVibes RSS aggregator.
   - [x] Cancel stale kanban tasks.
   - [x] Enact `docs/process/jules-pr-workflow.md` with five-gate review loop.
   - [x] Validate full test suite passes at restored state.
+
+*   [x] **2026-08-05: Remove non-portable host volume mount from Quadlet config** (PR #500)

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -3,7 +3,7 @@
 export const API_BASE_URL =
     (window.APP_CONFIG && window.APP_CONFIG.API_BASE_URL) ||
     window.API_BASE_URL ||
-    '';
+    (window.location.pathname.startsWith('/sheepvibes') ? '/sheepvibes' : '');
 
 /**
  * Fetches data from the specified API endpoint.

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -15,6 +15,7 @@ export function throttle(callback, delay) {
             lastThis = this;
             return;
         }
+        }
 
         callback.apply(this, args);
         isThrottled = true;

--- a/pod/sheepvibes-app.container
+++ b/pod/sheepvibes-app.container
@@ -10,6 +10,10 @@ Pod=sheepvibespod.pod
 Volume=sheepvibes-db.volume:/app/data
 Volume=/mnt/DATA/boy/prod/SheepVibes/frontend:/app/frontend:ro
 Environment=DATABASE_PATH=/app/data/sheepvibes.db
+HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:5000/')"
+HealthInterval=15s
+HealthTimeout=5s
+HealthRetries=3
 Environment=CACHE_REDIS_URL=redis://localhost:6379/0
 Environment=FLASK_APP=backend.app
 Environment=PYTHONPATH=/app

--- a/pod/sheepvibes-app.container
+++ b/pod/sheepvibes-app.container
@@ -8,7 +8,7 @@ ContainerName=sheepvibes-app
 Image=ghcr.io/sheepdestroyer/sheepvibes:latest
 Pod=sheepvibespod.pod
 Volume=sheepvibes-db.volume:/app/data
-Volume=/mnt/DATA/boy/SheepVibes/frontend:/app/frontend:ro
+Volume=/mnt/DATA/boy/prod/SheepVibes/frontend:/app/frontend:ro
 Environment=DATABASE_PATH=/app/data/sheepvibes.db
 Environment=CACHE_REDIS_URL=redis://localhost:6379/0
 Environment=FLASK_APP=backend.app

--- a/pod/sheepvibes-app.container
+++ b/pod/sheepvibes-app.container
@@ -8,6 +8,7 @@ ContainerName=sheepvibes-app
 Image=ghcr.io/sheepdestroyer/sheepvibes:latest
 Pod=sheepvibespod.pod
 Volume=sheepvibes-db.volume:/app/data
+Volume=/mnt/DATA/boy/SheepVibes/frontend:/app/frontend:ro
 Environment=DATABASE_PATH=/app/data/sheepvibes.db
 Environment=CACHE_REDIS_URL=redis://localhost:6379/0
 Environment=FLASK_APP=backend.app

--- a/pod/sheepvibes-app.container
+++ b/pod/sheepvibes-app.container
@@ -8,7 +8,6 @@ ContainerName=sheepvibes-app
 Image=ghcr.io/sheepdestroyer/sheepvibes:latest
 Pod=sheepvibespod.pod
 Volume=sheepvibes-db.volume:/app/data
-Volume=/mnt/DATA/boy/prod/SheepVibes/frontend:/app/frontend:ro
 Environment=DATABASE_PATH=/app/data/sheepvibes.db
 HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:5000/')"
 HealthInterval=15s

--- a/pod/sheepvibespod.pod
+++ b/pod/sheepvibespod.pod
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Pod]
-PublishPort=127.0.0.1:5001:5000
+PublishPort=127.0.0.1:5002:5000
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Resolves the port conflict with user sheepdestroyer by changing the mapped port to 5002, and resolves 404 errors by dynamically setting API_BASE_URL to prepend /sheepvibes when hosted under the proxy subpath.

## Summary by Sourcery

Adjust client API base URL and container configuration to support reverse proxy subpath deployment without port conflicts.

Enhancements:
- Update frontend API base URL fallback to automatically prepend the /sheepvibes subpath when the app is served under that route.

Deployment:
- Modify pod/container configuration for the sheepvibes app to avoid port conflicts in reverse proxy setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application routing so frontend requests work correctly when hosted under the `/sheepvibes` path.
  * Added container health monitoring to help detect unavailable application instances.

* **Configuration**
  * Updated the local service port from 5001 to 5002.
  * Added read-only access to frontend assets within the application container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->