### PR TITLE
test(feeds): comprehensive unit test suite for comments & discussion links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   - **Backend Data Model & Extraction**: Added `comments_url` column to `FeedItem` model, database migration (`8e59ae7a1c5b`), and feed parsing support in `backend/feed_service.py` to extract and validate `<comments>` tags (RSS 2.0) and `rel="replies"` links (Atom).
   - **API Serialization**: Updated `FeedItem.to_dict()` and `_get_top_items_for_feeds` in `backend/blueprints/tabs.py` to return `comments_url`.
   - **Frontend UI & Accessibility**: When comments thread URL is present and differs from article link, the primary item title link opens the discussion thread (default/primary), and a secondary `[article]` link opens the original article. Added full click and middle-click (`auxclick`) mark-as-read handlers, URL sanitization, and WCAG AA contrast styling in light and night modes.
-  - **Testing**: Added unit tests in `tests/unit/test_feed.py`, `tests/unit/test_app.py`, and `frontend/js/ui.test.js`. Verified 100% test pass rate across Vitest (25/25), Pytest unit tests (166/166), and Playwright E2E suite (3/3).
+  - **Testing**: Added comprehensive unit tests in `tests/unit/test_feed.py`, `tests/unit/test_app.py`, and `frontend/js/ui.test.js` covering real-world Hacker News & Lobsters RSS XML parsing, Atom `replies`/`discussion`/`comments` links, malformed URL rejection, DB update idempotency, API serialization/pagination, and frontend click/middle-click mark-as-read interactions. Verified 100% test pass rate across Vitest (36/36), Pytest unit tests (173/173), and Playwright E2E suite (3/3).
 
 ## 2026-08-13
 

--- a/TODO.md
+++ b/TODO.md
@@ -152,7 +152,14 @@ This document outlines the steps to build the SheepVibes RSS aggregator.
   - [x] Implemented feed parser comments extraction and URL structure validation in `backend/feed_service.py` supporting RSS 2.0 `<comments>` and Atom `rel="replies"`.
   - [x] Updated API serializers in `backend/models.py` and `backend/blueprints/tabs.py`.
   - [x] Implemented UI rendering in `frontend/js/ui.js` and `frontend/style.css` to make discussion thread primary/default and provide a secondary `[article]` link with unread status marking on click/middle-click.
-  - [x] Added unit tests across Pytest backend and Vitest frontend; verified 100% test pass rate across Vitest (25/25), Pytest unit (166/166), and Playwright E2E (3/3).
+  - [x] Added comprehensive unit test suite across Pytest backend and Vitest frontend:
+    - RSS 2.0 real XML parsing for Hacker News and Lobsters feeds (story posts vs. ask/self-posts).
+    - Atom link rel variations (`replies`, `discussion`, `comments`).
+    - Malformed and unsafe URL filtering (non-string, whitespace, non-http/https schemes).
+    - Database update idempotency and upstream omitted-comments preservation.
+    - API serialization and pagination comments_url preservation in `FeedItem.to_dict()` and `_get_top_items_for_feeds`.
+    - Frontend Vitest suite covering discussion links, secondary article links, URL sanitization, and click/middle-click mark-as-read handlers.
+    - Verified 100% test pass rate across Vitest (36/36), Pytest unit (173/173), and Playwright E2E (3/3).
 
 *   [x] **2026-08-13: Documentation Overhaul & Automated Release Workflow**
   - [x] Published GitHub Releases for `v0.26` (Valkey standardization) and `v0.27` (Night Mode, WCAG AA contrast, and Dependabot updates).

--- a/frontend/js/ui.test.js
+++ b/frontend/js/ui.test.js
@@ -1,8 +1,20 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect } from 'vitest';
-import { createBadge, createFeedWidget } from './ui.js';
+import { describe, it, expect, vi } from 'vitest';
+import {
+    createBadge,
+    updateUnreadCount,
+    createFeedWidget,
+    appendItemsToFeedWidget,
+    renderTabs,
+    showToast,
+    showProgress,
+    updateProgress,
+    hideProgress,
+    showEditFeedModal,
+    closeEditFeedModal
+} from './ui.js';
 
 describe('createBadge', () => {
     it('returns null if count is 0', () => {
@@ -15,6 +27,11 @@ describe('createBadge', () => {
         expect(badge).toBeNull();
     });
 
+    it('returns null if count is null or undefined', () => {
+        expect(createBadge(null)).toBeNull();
+        expect(createBadge(undefined)).toBeNull();
+    });
+
     it('creates a span element with correct classes and text content for a positive count', () => {
         const badge = createBadge(10);
 
@@ -22,6 +39,41 @@ describe('createBadge', () => {
         expect(badge.tagName).toBe('SPAN');
         expect(badge.classList.contains('unread-count-badge')).toBe(true);
         expect(badge.textContent).toBe('10');
+    });
+});
+
+describe('updateUnreadCount', () => {
+    it('decrements unread badge count when count is greater than 1', () => {
+        const container = document.createElement('div');
+        const badge = createBadge(5);
+        container.appendChild(badge);
+
+        updateUnreadCount(container);
+        expect(container.querySelector('.unread-count-badge')).not.toBeNull();
+        expect(container.querySelector('.unread-count-badge').textContent).toBe('4');
+    });
+
+    it('removes unread badge element when count decrements to 0', () => {
+        const container = document.createElement('div');
+        const badge = createBadge(1);
+        container.appendChild(badge);
+
+        updateUnreadCount(container);
+        expect(container.querySelector('.unread-count-badge')).toBeNull();
+    });
+
+    it('gracefully handles elements without badges or invalid content', () => {
+        const emptyContainer = document.createElement('div');
+        expect(() => updateUnreadCount(emptyContainer)).not.toThrow();
+
+        const invalidBadgeContainer = document.createElement('div');
+        const invalidBadge = document.createElement('span');
+        invalidBadge.className = 'unread-count-badge';
+        invalidBadge.textContent = 'not-a-number';
+        invalidBadgeContainer.appendChild(invalidBadge);
+
+        expect(() => updateUnreadCount(invalidBadgeContainer)).not.toThrow();
+        expect(() => updateUnreadCount(null)).not.toThrow();
     });
 });
 
@@ -62,14 +114,48 @@ describe('createFeedWidget URL sanitization', () => {
         const articleLink = widget.querySelector('.item-article-link');
         expect(articleLink.getAttribute('href')).toBe('#');
     });
+
+    it('preserves safe URL schemes for both discussion and article links', () => {
+        const feed = {
+            id: 1,
+            tab_id: 1,
+            name: 'Safe Feed',
+            site_link: 'https://news.ycombinator.com',
+            url: 'https://news.ycombinator.com/rss',
+            unread_count: 0,
+            items: [
+                {
+                    id: 102,
+                    title: 'Safe Item',
+                    link: 'https://example.com/article',
+                    comments_url: 'https://news.ycombinator.com/item?id=123',
+                    is_read: false,
+                    published_time: '2026-01-01T00:00:00Z'
+                }
+            ]
+        };
+
+        const widget = createFeedWidget(feed, {
+            onEdit: () => {},
+            onDelete: () => {},
+            onMarkItemRead: () => {},
+            onLoadMore: () => {}
+        });
+
+        const titleLink = widget.querySelector('ul li a:not(.item-article-link)');
+        expect(titleLink.getAttribute('href')).toBe('https://news.ycombinator.com/item?id=123');
+
+        const articleLink = widget.querySelector('.item-article-link');
+        expect(articleLink.getAttribute('href')).toBe('https://example.com/article');
+    });
 });
 
 describe('createFeedWidget comments_url and article link handling', () => {
     it('sets comments thread as primary title link and renders secondary article link when comments_url differs from link', () => {
-        let markedReadId = null;
+        let markedReadCalls = [];
         const feed = {
             id: 1,
-            tab_id: 1,
+            tab_id: 2,
             name: 'Hacker News',
             url: 'https://news.ycombinator.com/rss',
             unread_count: 1,
@@ -88,35 +174,70 @@ describe('createFeedWidget comments_url and article link handling', () => {
         const widget = createFeedWidget(feed, {
             onEdit: () => {},
             onDelete: () => {},
-            onMarkItemRead: (id) => { markedReadId = id; },
+            onMarkItemRead: (id, li, feedId, tabId) => {
+                markedReadCalls.push({ id, li, feedId, tabId });
+            },
             onLoadMore: () => {}
         });
 
+        const listItem = widget.querySelector('ul li');
+        expect(listItem.classList.contains('unread')).toBe(true);
+        expect(listItem.classList.contains('read')).toBe(false);
+        expect(listItem.dataset.itemId).toBe('201');
+
+        // Primary title link
         const titleLink = widget.querySelector('ul li a:not(.item-article-link)');
         expect(titleLink).not.toBeNull();
         expect(titleLink.getAttribute('href')).toBe('https://news.ycombinator.com/item?id=49289112');
         expect(titleLink.textContent).toBe('Show HN: SheepVibes');
         expect(titleLink.getAttribute('title')).toBe('Open discussion thread');
+        expect(titleLink.getAttribute('target')).toBe('_blank');
+        expect(titleLink.getAttribute('rel')).toBe('noopener noreferrer');
+
+        // Secondary article link
+        const metaSpan = widget.querySelector('ul li .item-meta');
+        expect(metaSpan).not.toBeNull();
+        expect(metaSpan.textContent).toContain(' · ');
 
         const articleLink = widget.querySelector('ul li .item-article-link');
         expect(articleLink).not.toBeNull();
         expect(articleLink.getAttribute('href')).toBe('https://github.com/sheepdestroyer/SheepVibes');
         expect(articleLink.textContent).toBe('[article]');
         expect(articleLink.getAttribute('title')).toBe('Open original article');
+        expect(articleLink.getAttribute('aria-label')).toBe('Open original article: Show HN: SheepVibes');
+        expect(articleLink.getAttribute('target')).toBe('_blank');
+        expect(articleLink.getAttribute('rel')).toBe('noopener noreferrer');
 
-        // Test clicking title link triggers mark read
+        // Test clicking primary title link triggers mark read with proper arguments
         titleLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        expect(markedReadId).toBe(201);
+        expect(markedReadCalls).toHaveLength(1);
+        expect(markedReadCalls[0]).toEqual({
+            id: 201,
+            li: listItem,
+            feedId: 1,
+            tabId: 2
+        });
 
-        markedReadId = null;
+        // Test middle-click (button 1) on primary title link
+        titleLink.dispatchEvent(new MouseEvent('auxclick', { button: 1, bubbles: true }));
+        expect(markedReadCalls).toHaveLength(2);
+
+        // Test right-click (button 2) on primary title link does NOT trigger mark read
+        titleLink.dispatchEvent(new MouseEvent('auxclick', { button: 2, bubbles: true }));
+        expect(markedReadCalls).toHaveLength(2);
+
         // Test clicking secondary article link triggers mark read
         articleLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        expect(markedReadId).toBe(201);
+        expect(markedReadCalls).toHaveLength(3);
+        expect(markedReadCalls[2].id).toBe(201);
 
-        markedReadId = null;
-        // Test middle-click (auxclick with button 1) triggers mark read
+        // Test middle-click (button 1) on secondary article link
         articleLink.dispatchEvent(new MouseEvent('auxclick', { button: 1, bubbles: true }));
-        expect(markedReadId).toBe(201);
+        expect(markedReadCalls).toHaveLength(4);
+
+        // Test right-click (button 2) on secondary article link does NOT trigger mark read
+        articleLink.dispatchEvent(new MouseEvent('auxclick', { button: 2, bubbles: true }));
+        expect(markedReadCalls).toHaveLength(4);
     });
 
     it('uses article link as primary and does not render secondary article link when comments_url is missing or equal to link', () => {
@@ -132,7 +253,7 @@ describe('createFeedWidget comments_url and article link handling', () => {
                     title: 'Standard Item No Comments',
                     link: 'https://example.com/standard-post',
                     comments_url: null,
-                    is_read: false,
+                    is_read: true,
                     published_time: '2026-08-14T00:00:00Z'
                 },
                 {
@@ -142,6 +263,22 @@ describe('createFeedWidget comments_url and article link handling', () => {
                     comments_url: 'https://news.ycombinator.com/item?id=49289200',
                     is_read: false,
                     published_time: '2026-08-14T00:05:00Z'
+                },
+                {
+                    id: 303,
+                    title: 'Whitespace Comments Item',
+                    link: 'https://example.com/whitespace-comments',
+                    comments_url: '   \t  ',
+                    is_read: false,
+                    published_time: '2026-08-14T00:10:00Z'
+                },
+                {
+                    id: 304,
+                    title: 'Non-string Comments Item',
+                    link: 'https://example.com/non-string-comments',
+                    comments_url: 12345,
+                    is_read: false,
+                    published_time: '2026-08-14T00:15:00Z'
                 }
             ]
         };
@@ -154,16 +291,221 @@ describe('createFeedWidget comments_url and article link handling', () => {
         });
 
         const listItems = widget.querySelectorAll('ul li');
-        expect(listItems.length).toBe(2);
+        expect(listItems.length).toBe(4);
 
-        // First item (no comments_url)
+        // First item (no comments_url, read state)
+        expect(listItems[0].classList.contains('read')).toBe(true);
+        expect(listItems[0].classList.contains('unread')).toBe(false);
         const item1TitleLink = listItems[0].querySelector('a');
         expect(item1TitleLink.getAttribute('href')).toBe('https://example.com/standard-post');
+        expect(item1TitleLink.hasAttribute('title')).toBe(false);
         expect(listItems[0].querySelector('.item-article-link')).toBeNull();
 
         // Second item (comments_url == link)
+        expect(listItems[1].classList.contains('unread')).toBe(true);
         const item2TitleLink = listItems[1].querySelector('a');
         expect(item2TitleLink.getAttribute('href')).toBe('https://news.ycombinator.com/item?id=49289200');
+        expect(item2TitleLink.hasAttribute('title')).toBe(false);
         expect(listItems[1].querySelector('.item-article-link')).toBeNull();
+
+        // Third item (whitespace comments_url)
+        const item3TitleLink = listItems[2].querySelector('a');
+        expect(item3TitleLink.getAttribute('href')).toBe('https://example.com/whitespace-comments');
+        expect(listItems[2].querySelector('.item-article-link')).toBeNull();
+
+        // Fourth item (non-string comments_url)
+        const item4TitleLink = listItems[3].querySelector('a');
+        expect(item4TitleLink.getAttribute('href')).toBe('https://example.com/non-string-comments');
+        expect(listItems[3].querySelector('.item-article-link')).toBeNull();
+    });
+
+    it('renders empty fallback text when feed has no items', () => {
+        const feed = {
+            id: 3,
+            tab_id: 1,
+            name: 'Empty Feed',
+            url: 'https://example.com/empty.xml',
+            unread_count: 0,
+            items: []
+        };
+
+        const widget = createFeedWidget(feed, {
+            onEdit: () => {},
+            onDelete: () => {},
+            onMarkItemRead: () => {},
+            onLoadMore: () => {}
+        });
+
+        const listItems = widget.querySelectorAll('ul li');
+        expect(listItems.length).toBe(1);
+        expect(listItems[0].textContent).toBe('No items found for this feed.');
+    });
+});
+
+describe('appendItemsToFeedWidget', () => {
+    it('appends items with mixed comments_url configurations and wires mark-as-read callbacks', () => {
+        let markedReadCalls = [];
+        const widgetList = document.createElement('ul');
+        widgetList.dataset.feedId = '10';
+        widgetList.dataset.tabId = '5';
+        widgetList.dataset.offset = '2';
+
+        const newItems = [
+            {
+                id: 401,
+                title: 'Appended HN Story',
+                link: 'https://example.com/appended-story',
+                comments_url: 'https://news.ycombinator.com/item?id=401',
+                is_read: false,
+                published_time: '2026-08-14T02:00:00Z'
+            },
+            {
+                id: 402,
+                title: 'Appended Plain Story',
+                link: 'https://example.com/plain-story',
+                comments_url: null,
+                is_read: true,
+                published_time: '2026-08-14T02:05:00Z'
+            }
+        ];
+
+        appendItemsToFeedWidget(widgetList, newItems, {
+            onMarkItemRead: (id, li, feedId, tabId) => {
+                markedReadCalls.push({ id, li, feedId, tabId });
+            }
+        });
+
+        // Offset updated
+        expect(widgetList.dataset.offset).toBe('4');
+
+        const listItems = widgetList.querySelectorAll('li');
+        expect(listItems.length).toBe(2);
+
+        // First item has discussion link and secondary article link
+        const item1 = listItems[0];
+        expect(item1.dataset.itemId).toBe('401');
+        expect(item1.classList.contains('unread')).toBe(true);
+
+        const item1Discussion = item1.querySelector('a:not(.item-article-link)');
+        expect(item1Discussion.getAttribute('href')).toBe('https://news.ycombinator.com/item?id=401');
+        expect(item1Discussion.getAttribute('title')).toBe('Open discussion thread');
+
+        const item1Article = item1.querySelector('.item-article-link');
+        expect(item1Article).not.toBeNull();
+        expect(item1Article.getAttribute('href')).toBe('https://example.com/appended-story');
+
+        // Test clicking appended article link marks item read
+        item1Article.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(markedReadCalls).toHaveLength(1);
+        expect(markedReadCalls[0]).toEqual({
+            id: 401,
+            li: item1,
+            feedId: '10',
+            tabId: '5'
+        });
+
+        // Second item has single link
+        const item2 = listItems[1];
+        expect(item2.dataset.itemId).toBe('402');
+        expect(item2.classList.contains('read')).toBe(true);
+        expect(item2.querySelector('.item-article-link')).toBeNull();
+    });
+});
+
+describe('renderTabs', () => {
+    it('renders tabs sorted by order with unread badges and active tab indicator', () => {
+        document.body.innerHTML = `
+            <div id="tabs-container"></div>
+            <div id="feed-grid"></div>
+            <button id="rename-tab-button"></button>
+            <button id="delete-tab-button"></button>
+        `;
+
+        let switchedTabId = null;
+        const tabs = [
+            { id: 2, name: 'Tech', order: 1, unread_count: 3 },
+            { id: 1, name: 'General', order: 0, unread_count: 0 }
+        ];
+
+        renderTabs(tabs, 2, {
+            onSwitchTab: (id) => { switchedTabId = id; }
+        });
+
+        const buttons = document.querySelectorAll('#tabs-container button');
+        expect(buttons.length).toBe(2);
+
+        // Sorted by order
+        expect(buttons[0].dataset.tabId).toBe('1');
+        expect(buttons[0].textContent).toBe('General');
+        expect(buttons[0].classList.contains('active')).toBe(false);
+        expect(buttons[0].querySelector('.unread-count-badge')).toBeNull();
+
+        expect(buttons[1].dataset.tabId).toBe('2');
+        expect(buttons[1].textContent).toContain('Tech');
+        expect(buttons[1].classList.contains('active')).toBe(true);
+        expect(buttons[1].querySelector('.unread-count-badge').textContent).toBe('3');
+
+        // Clicking switches tab
+        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(switchedTabId).toBe(1);
+    });
+
+    it('handles empty tabs array gracefully', () => {
+        document.body.innerHTML = `
+            <div id="tabs-container"></div>
+            <div id="feed-grid"></div>
+            <button id="rename-tab-button"></button>
+            <button id="delete-tab-button"></button>
+        `;
+
+        const result = renderTabs([], null, { onSwitchTab: () => {} });
+        expect(result.activeTabId).toBeNull();
+        expect(document.getElementById('tabs-container').textContent).toBe('No tabs found.');
+        expect(document.getElementById('rename-tab-button').disabled).toBe(true);
+        expect(document.getElementById('delete-tab-button').disabled).toBe(true);
+    });
+});
+
+describe('Modals and Progress helpers', () => {
+    it('opens and closes edit feed modal', () => {
+        document.body.innerHTML = `
+            <div id="edit-feed-modal">
+                <input id="edit-feed-id" />
+                <input id="edit-feed-url" />
+                <input id="edit-feed-name" />
+                <div id="edit-feed-error" class="hidden"></div>
+            </div>
+        `;
+
+        showEditFeedModal('12', 'https://example.com/feed.xml', 'Example Feed');
+        expect(document.getElementById('edit-feed-id').value).toBe('12');
+        expect(document.getElementById('edit-feed-url').value).toBe('https://example.com/feed.xml');
+        expect(document.getElementById('edit-feed-name').value).toBe('Example Feed');
+        expect(document.getElementById('edit-feed-modal').classList.contains('is-active')).toBe(true);
+
+        closeEditFeedModal();
+        expect(document.getElementById('edit-feed-modal').classList.contains('is-active')).toBe(false);
+    });
+
+    it('shows, updates, and hides progress bar', () => {
+        document.body.innerHTML = `
+            <div id="progress-container" class="hidden">
+                <span id="progress-status"></span>
+                <progress id="progress-bar" value="0" max="100"></progress>
+            </div>
+        `;
+
+        showProgress('Starting download...');
+        expect(document.getElementById('progress-status').textContent).toBe('Starting download...');
+        expect(document.getElementById('progress-bar').value).toBe(0);
+        expect(document.getElementById('progress-container').classList.contains('hidden')).toBe(false);
+
+        updateProgress('Processing items...', 50, 100);
+        expect(document.getElementById('progress-status').textContent).toBe('Processing items...');
+        expect(document.getElementById('progress-bar').value).toBe(50);
+        expect(document.getElementById('progress-bar').max).toBe(100);
+
+        hideProgress();
+        expect(document.getElementById('progress-container').classList.contains('hidden')).toBe(true);
     });
 });

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2397,3 +2397,103 @@ def test_get_feed_items_and_tab_feeds_include_comments_url(client, setup_tabs_an
     assert matching_tab_item is not None
     assert matching_tab_item["comments_url"] == "https://news.ycombinator.com/item?id=8888"
     assert matching_tab_item["link"] == "https://example.com/story-123"
+
+
+def test_get_top_items_for_feeds_direct_serialization(client):  # pylint: disable=unused-argument
+    """Directly test _get_top_items_for_feeds in backend.blueprints.tabs for comments_url."""
+    from backend.blueprints.tabs import _get_top_items_for_feeds
+    from datetime import datetime, timezone
+
+    with app.app_context():
+        tab = Tab(name="Serialization Tab", order=1)
+        db.session.add(tab)
+        db.session.commit()
+        feed = Feed(name="Serialization Feed", url="https://example.com/rss", tab_id=tab.id)
+        db.session.add(feed)
+        db.session.commit()
+
+        item1 = FeedItem(
+            feed_id=feed.id,
+            title="Item 1 (With Comments)",
+            link="https://example.com/article1",
+            comments_url="https://news.ycombinator.com/item?id=101",
+            guid="guid-101",
+            published_time=datetime(2026, 8, 14, 1, 0, 0, tzinfo=timezone.utc),
+        )
+        item2 = FeedItem(
+            feed_id=feed.id,
+            title="Item 2 (Without Comments)",
+            link="https://example.com/article2",
+            comments_url=None,
+            guid="guid-102",
+            published_time=datetime(2026, 8, 14, 0, 50, 0, tzinfo=timezone.utc),
+        )
+        item3 = FeedItem(
+            feed_id=feed.id,
+            title="Item 3 (Comments == Link)",
+            link="https://news.ycombinator.com/item?id=103",
+            comments_url="https://news.ycombinator.com/item?id=103",
+            guid="guid-103",
+            published_time=datetime(2026, 8, 14, 0, 40, 0, tzinfo=timezone.utc),
+        )
+        db.session.add_all([item1, item2, item3])
+        db.session.commit()
+
+        items_by_feed = _get_top_items_for_feeds([feed.id], limit=5)
+        assert feed.id in items_by_feed
+        results = items_by_feed[feed.id]
+        assert len(results) == 3
+
+        assert results[0]["title"] == "Item 1 (With Comments)"
+        assert results[0]["comments_url"] == "https://news.ycombinator.com/item?id=101"
+        assert results[0]["link"] == "https://example.com/article1"
+
+        assert results[1]["title"] == "Item 2 (Without Comments)"
+        assert results[1]["comments_url"] is None
+        assert results[1]["link"] == "https://example.com/article2"
+
+        assert results[2]["title"] == "Item 3 (Comments == Link)"
+        assert results[2]["comments_url"] == "https://news.ycombinator.com/item?id=103"
+        assert results[2]["link"] == "https://news.ycombinator.com/item?id=103"
+
+
+def test_feed_items_pagination_comments_url_preservation(client, setup_tabs_and_feeds):
+    """Test pagination limits and offsets in /api/feeds/<feed_id>/items preserving comments_url."""
+    from datetime import datetime, timezone
+
+    feed_id = setup_tabs_and_feeds["feed1_id"]
+    with app.app_context():
+        # Clear existing items for this feed
+        FeedItem.query.filter_by(feed_id=feed_id).delete()
+        for i in range(5):
+            db.session.add(
+                FeedItem(
+                    feed_id=feed_id,
+                    title=f"Paginated Item {i}",
+                    link=f"https://example.com/item-{i}",
+                    comments_url=f"https://news.ycombinator.com/item?id={i + 1000}" if i % 2 == 0 else None,
+                    guid=f"paginated-guid-{i}",
+                    published_time=datetime(2026, 8, 14, 0, 50 - i, 0, tzinfo=timezone.utc),
+                )
+            )
+        db.session.commit()
+
+    # Page 1: limit 2, offset 0
+    resp1 = client.get(f"/api/feeds/{feed_id}/items?limit=2&offset=0")
+    assert resp1.status_code == 200
+    page1 = resp1.json
+    assert len(page1) == 2
+    assert page1[0]["title"] == "Paginated Item 0"
+    assert page1[0]["comments_url"] == "https://news.ycombinator.com/item?id=1000"
+    assert page1[1]["title"] == "Paginated Item 1"
+    assert page1[1]["comments_url"] is None
+
+    # Page 2: limit 2, offset 2
+    resp2 = client.get(f"/api/feeds/{feed_id}/items?limit=2&offset=2")
+    assert resp2.status_code == 200
+    page2 = resp2.json
+    assert len(page2) == 2
+    assert page2[0]["title"] == "Paginated Item 2"
+    assert page2[0]["comments_url"] == "https://news.ycombinator.com/item?id=1002"
+    assert page2[1]["title"] == "Paginated Item 3"
+    assert page2[1]["comments_url"] is None

--- a/tests/unit/test_feed.py
+++ b/tests/unit/test_feed.py
@@ -937,7 +937,7 @@ def test_fetch_feed_toctou_prevention_http(mocker):
 
 
 def test_kernel_org_subsequent_update_adds_new_items(db_setup, mocker):
-    """Test that subsequent updates to feeds with shared links (e.g. Kernel.org) insert new items rather than overwriting."""
+    """Test that subsequent updates to feeds with shared links (e.g. Kernel.org) insert new items."""
     tab = Tab(name="Tech", order=1)
     db.session.add(tab)
     db.session.commit()
@@ -946,21 +946,27 @@ def test_kernel_org_subsequent_update_adds_new_items(db_setup, mocker):
     db.session.commit()
 
     # Initial 2 items
-    entry1 = MockFeedEntry(title="Kernel 1", link="https://www.kernel.org/", guid="kernel.guid.1", published="2024-01-01T10:00:00Z")
-    entry2 = MockFeedEntry(title="Kernel 2", link="https://www.kernel.org/", guid="kernel.guid.2", published="2024-01-02T10:00:00Z")
+    entry1 = MockFeedEntry(
+        title="Kernel 1", link="https://www.kernel.org/", guid="kernel.guid.1", published="2024-01-01T10:00:00Z"
+    )
+    entry2 = MockFeedEntry(
+        title="Kernel 2", link="https://www.kernel.org/", guid="kernel.guid.2", published="2024-01-02T10:00:00Z"
+    )
     mock_feed_1 = MockParsedFeed(feed_title="Kernel Updates", entries=[entry1, entry2])
-    
+
     count1 = feed_service.process_feed_entries(feed_obj, mock_feed_1)
     assert count1 == 2
     assert FeedItem.query.filter_by(feed_id=feed_obj.id).count() == 2
 
     # Subsequent update with entry3 having a new GUID but same link
-    entry3 = MockFeedEntry(title="Kernel 3", link="https://www.kernel.org/", guid="kernel.guid.3", published="2024-01-03T10:00:00Z")
+    entry3 = MockFeedEntry(
+        title="Kernel 3", link="https://www.kernel.org/", guid="kernel.guid.3", published="2024-01-03T10:00:00Z"
+    )
     mock_feed_2 = MockParsedFeed(feed_title="Kernel Updates", entries=[entry1, entry2, entry3])
 
     count2 = feed_service.process_feed_entries(feed_obj, mock_feed_2)
     assert count2 == 1, "Subsequent update with new GUID should add 1 new item"
-    
+
     items = FeedItem.query.filter_by(feed_id=feed_obj.id).all()
     assert len(items) == 3
     guids_in_db = {it.guid for it in items}
@@ -1115,3 +1121,274 @@ def test_update_existing_item_with_comments_url(db_setup):  # pylint: disable=un
     assert updated_item.title == "Updated Title"
     assert updated_item.comments_url == "https://news.ycombinator.com/item?id=9999"
 
+
+def test_hacker_news_real_xml_feedparser_parsing(db_setup):  # pylint: disable=unused-argument
+    """Test full parsing and DB ingestion of real-world Hacker News RSS 2.0 XML."""
+    import feedparser  # pylint: disable=import-outside-toplevel
+
+    hn_rss_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Hacker News</title>
+    <link>https://news.ycombinator.com/</link>
+    <description>Links for the intellectually curious, something that you might find interesting.</description>
+    <item>
+      <title>Show HN: SheepVibes – Self-hosted feed aggregator</title>
+      <link>https://github.com/sheepdestroyer/SheepVibes</link>
+      <pubDate>Fri, 14 Aug 2026 00:00:00 +0000</pubDate>
+      <comments>https://news.ycombinator.com/item?id=49289112</comments>
+      <description><![CDATA[<a href="https://news.ycombinator.com/item?id=49289112">Comments</a>]]></description>
+    </item>
+    <item>
+      <title>Ask HN: How do you organize your personal feeds?</title>
+      <link>https://news.ycombinator.com/item?id=49289200</link>
+      <pubDate>Fri, 14 Aug 2026 00:10:00 +0000</pubDate>
+      <comments>https://news.ycombinator.com/item?id=49289200</comments>
+      <description><![CDATA[<a href="https://news.ycombinator.com/item?id=49289200">Comments</a>]]></description>
+    </item>
+  </channel>
+</rss>"""
+    parsed = feedparser.parse(hn_rss_xml)
+    tab = Tab(name="News HN XML", order=1)
+    db.session.add(tab)
+    db.session.commit()
+    feed_obj = Feed(name="Hacker News XML Feed", url="https://news.ycombinator.com/rss", tab_id=tab.id)
+    db.session.add(feed_obj)
+    db.session.commit()
+
+    count = feed_service.process_feed_entries(feed_obj, parsed)
+    assert count == 2
+
+    items = FeedItem.query.filter_by(feed_id=feed_obj.id).order_by(FeedItem.published_time.asc()).all()
+    assert len(items) == 2
+
+    story_item = items[0]
+    assert story_item.title == "Show HN: SheepVibes – Self-hosted feed aggregator"
+    assert story_item.link == "https://github.com/sheepdestroyer/SheepVibes"
+    assert story_item.comments_url == "https://news.ycombinator.com/item?id=49289112"
+
+    ask_item = items[1]
+    assert ask_item.title == "Ask HN: How do you organize your personal feeds?"
+    assert ask_item.link == "https://news.ycombinator.com/item?id=49289200"
+    assert ask_item.comments_url == "https://news.ycombinator.com/item?id=49289200"
+
+
+def test_lobsters_real_xml_feedparser_parsing(db_setup):  # pylint: disable=unused-argument
+    """Test full parsing and DB ingestion of real-world Lobsters RSS 2.0 XML."""
+    import feedparser  # pylint: disable=import-outside-toplevel
+
+    lobsters_rss_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Lobsters</title>
+    <link>https://lobste.rs/</link>
+    <description></description>
+    <item>
+      <title>PostgreSQL 18 Features and Improvements</title>
+      <link>https://brandur.org/postgres-18</link>
+      <guid isPermaLink="false">https://lobste.rs/s/xyz123/postgresql_18_features</guid>
+      <author>brandur</author>
+      <pubDate>Fri, 14 Aug 2026 00:30:00 +0000</pubDate>
+      <comments>https://lobste.rs/s/xyz123/postgresql_18_features</comments>
+      <description><![CDATA[<p><a href="https://lobste.rs/s/xyz123/postgres">Comments</a></p>]]></description>
+    </item>
+    <item>
+      <title>Tell Lobsters: Favorite SQL Migrations Tool?</title>
+      <link>https://lobste.rs/s/abc456/tell_lobsters_favorite_sql_migrations</link>
+      <guid isPermaLink="false">https://lobste.rs/s/abc456/tell_lobsters_favorite_sql_migrations</guid>
+      <author>jcs</author>
+      <pubDate>Fri, 14 Aug 2026 01:00:00 +0000</pubDate>
+      <comments>https://lobste.rs/s/abc456/tell_lobsters_favorite_sql_migrations</comments>
+      <description><![CDATA[<p><a href="https://lobste.rs/s/abc456/tell">Comments</a></p>]]></description>
+    </item>
+  </channel>
+</rss>"""
+    parsed = feedparser.parse(lobsters_rss_xml)
+    tab = Tab(name="Tech Lobsters XML", order=1)
+    db.session.add(tab)
+    db.session.commit()
+    feed_obj = Feed(name="Lobsters XML Feed", url="https://lobste.rs/rss", tab_id=tab.id)
+    db.session.add(feed_obj)
+    db.session.commit()
+
+    count = feed_service.process_feed_entries(feed_obj, parsed)
+    assert count == 2
+
+    items = FeedItem.query.filter_by(feed_id=feed_obj.id).order_by(FeedItem.published_time.asc()).all()
+    assert len(items) == 2
+
+    story = items[0]
+    assert story.title == "PostgreSQL 18 Features and Improvements"
+    assert story.link == "https://brandur.org/postgres-18"
+    assert story.comments_url == "https://lobste.rs/s/xyz123/postgresql_18_features"
+    assert story.guid == "https://lobste.rs/s/xyz123/postgresql_18_features"
+
+    tell_post = items[1]
+    assert tell_post.title == "Tell Lobsters: Favorite SQL Migrations Tool?"
+    assert tell_post.link == "https://lobste.rs/s/abc456/tell_lobsters_favorite_sql_migrations"
+    assert tell_post.comments_url == "https://lobste.rs/s/abc456/tell_lobsters_favorite_sql_migrations"
+    assert tell_post.guid == "https://lobste.rs/s/abc456/tell_lobsters_favorite_sql_migrations"
+
+
+def test_atom_feed_discussion_and_comments_rel_links(db_setup, mocker):  # pylint: disable=unused-argument
+    """Test Atom feeds with rel='discussion', rel='comments', and multiple link relations."""
+    entry_discussion = MockFeedEntry(
+        title="Atom Discussion Link",
+        link="https://example.com/article-1",
+        links=[
+            {"rel": "alternate", "href": "https://example.com/article-1"},
+            {"rel": "discussion", "href": "https://example.com/discussions/123"},
+        ],
+        published="2026-08-14T01:00:00Z",
+    )
+    entry_comments = MockFeedEntry(
+        title="Atom Comments Link",
+        link="https://example.com/article-2",
+        links=[
+            {"rel": "alternate", "href": "https://example.com/article-2"},
+            {"rel": "comments", "href": "https://example.com/comments/456"},
+        ],
+        published="2026-08-14T01:05:00Z",
+    )
+    entry_fallback = MockFeedEntry(
+        title="Atom Multiple Links with Malformed Candidate",
+        link="https://example.com/article-3",
+        links=[
+            {"rel": "replies", "href": "javascript:alert(1)"},
+            {"rel": "replies", "href": ""},
+            {"rel": "enclosure", "href": "https://example.com/media.mp3"},
+        ],
+        published="2026-08-14T01:10:00Z",
+    )
+    mock_feed = MockParsedFeed(
+        feed_title="Atom Link Variations",
+        entries=[entry_discussion, entry_comments, entry_fallback],
+    )
+    mocker.patch("backend.feed_service.feedparser.parse", return_value=mock_feed)
+
+    tab = Tab(name="Atom Tab", order=1)
+    db.session.add(tab)
+    db.session.commit()
+    feed_obj = Feed(name="Atom Feed Variations", url="https://example.com/atom-var.xml", tab_id=tab.id)
+    db.session.add(feed_obj)
+    db.session.commit()
+
+    count = feed_service.process_feed_entries(feed_obj, mock_feed)
+    assert count == 3
+
+    items = {it.title: it for it in FeedItem.query.filter_by(feed_id=feed_obj.id).all()}
+    assert items["Atom Discussion Link"].comments_url == "https://example.com/discussions/123"
+    assert items["Atom Comments Link"].comments_url == "https://example.com/comments/456"
+    assert items["Atom Multiple Links with Malformed Candidate"].comments_url is None
+
+
+def test_malformed_and_edge_case_comments_urls(db_setup, mocker):  # pylint: disable=unused-argument
+    """Test feeds with non-string, whitespace, protocol-relative, or unsafe comment URLs."""
+    entries = [
+        MockFeedEntry(
+            title="Int Comments", link="https://example.com/1",
+            comments=12345, published="2026-08-14T01:00:00Z",
+        ),
+        MockFeedEntry(
+            title="Dict Comments", link="https://example.com/2",
+            comments={"url": "https://example.com"}, published="2026-08-14T01:01:00Z",
+        ),
+        MockFeedEntry(
+            title="List Comments", link="https://example.com/3",
+            comments=["https://example.com"], published="2026-08-14T01:02:00Z",
+        ),
+        MockFeedEntry(
+            title="Whitespace Comments", link="https://example.com/4",
+            comments="   \t\n  ", published="2026-08-14T01:03:00Z",
+        ),
+        MockFeedEntry(
+            title="Data Scheme", link="https://example.com/5",
+            comments="data:text/html,<script>alert(1)</script>", published="2026-08-14T01:04:00Z",
+        ),
+        MockFeedEntry(
+            title="File Scheme", link="https://example.com/6",
+            comments="file:///etc/passwd", published="2026-08-14T01:05:00Z",
+        ),
+        MockFeedEntry(
+            title="FTP Scheme", link="https://example.com/7",
+            comments="ftp://example.com/comments", published="2026-08-14T01:06:00Z",
+        ),
+        MockFeedEntry(
+            title="Mailto Scheme", link="https://example.com/8",
+            comments="mailto:user@example.com", published="2026-08-14T01:07:00Z",
+        ),
+        MockFeedEntry(
+            title="Protocol Relative", link="https://example.com/9",
+            comments="//example.com/comments", published="2026-08-14T01:08:00Z",
+        ),
+        MockFeedEntry(
+            title="No Netloc", link="https://example.com/10",
+            comments="https://", published="2026-08-14T01:09:00Z",
+        ),
+    ]
+    mock_feed = MockParsedFeed(feed_title="Malformed Edge Feed", entries=entries)
+    mocker.patch("backend.feed_service.feedparser.parse", return_value=mock_feed)
+
+    tab = Tab(name="Edge Tab", order=1)
+    db.session.add(tab)
+    db.session.commit()
+    feed_obj = Feed(name="Edge Feed", url="https://example.com/edge.xml", tab_id=tab.id)
+    db.session.add(feed_obj)
+    db.session.commit()
+
+    count = feed_service.process_feed_entries(feed_obj, mock_feed)
+    assert count == 10
+
+    items = FeedItem.query.filter_by(feed_id=feed_obj.id).all()
+    for item in items:
+        assert item.comments_url is None, f"Expected None for {item.title}, got {item.comments_url}"
+
+
+def test_database_update_idempotency_and_omitted_comments(db_setup):  # pylint: disable=unused-argument
+    """Test idempotency: comments_url is preserved when omitted upstream and updated when changed."""
+    tab = Tab(name="Idempotency Tab", order=1)
+    db.session.add(tab)
+    db.session.commit()
+    feed_obj = Feed(name="Idempotency Feed", url="https://example.com/feed.xml", tab_id=tab.id)
+    db.session.add(feed_obj)
+    db.session.commit()
+
+    # Step 1: Initial item with comments_url
+    entry1 = MockFeedEntry(
+        title="HN Story",
+        link="https://example.com/story-1",
+        guid="hn-guid-1",
+        comments="https://news.ycombinator.com/item?id=111",
+        published="2026-08-14T00:00:00Z",
+    )
+    feed_service.process_feed_entries(feed_obj, MockParsedFeed(feed_title="Idempotency Feed", entries=[entry1]))
+
+    item = FeedItem.query.filter_by(feed_id=feed_obj.id, guid="hn-guid-1").first()
+    assert item.comments_url == "https://news.ycombinator.com/item?id=111"
+
+    # Step 2: Feed refresh where comments tag is temporarily omitted / missing (comments=None)
+    entry_omitted = MockFeedEntry(
+        title="HN Story",
+        link="https://example.com/story-1",
+        guid="hn-guid-1",
+        comments=None,
+        published="2026-08-14T00:00:00Z",
+    )
+    feed_service.process_feed_entries(feed_obj, MockParsedFeed(feed_title="Idempotency Feed", entries=[entry_omitted]))
+
+    # Must retain original comments_url and NOT overwrite with None
+    item_recheck = FeedItem.query.filter_by(feed_id=feed_obj.id, guid="hn-guid-1").first()
+    assert item_recheck.comments_url == "https://news.ycombinator.com/item?id=111"
+
+    # Step 3: Feed refresh where comments_url is updated to a new URL
+    entry_updated = MockFeedEntry(
+        title="HN Story",
+        link="https://example.com/story-1",
+        guid="hn-guid-1",
+        comments="https://news.ycombinator.com/item?id=222",
+        published="2026-08-14T00:00:00Z",
+    )
+    feed_service.process_feed_entries(feed_obj, MockParsedFeed(feed_title="Idempotency Feed", entries=[entry_updated]))
+
+    item_updated = FeedItem.query.filter_by(feed_id=feed_obj.id, guid="hn-guid-1").first()
+    assert item_updated.comments_url == "https://news.ycombinator.com/item?id=222"


### PR DESCRIPTION
## Summary

This PR introduces a dedicated, comprehensive unit test suite covering the new Hacker News & Lobsters comments and discussion thread link feature in SheepVibes.

### Test Coverage Highlights

1. **RSS 2.0 Real XML Feed Ingestion (`tests/unit/test_feed.py`)**:
   - Real-world Hacker News RSS 2.0 XML parsing with story posts (external article link + comments URL) and self/Ask HN posts (comments URL == article link).
   - Real-world Lobsters RSS 2.0 XML parsing with story posts and text posts.
2. **Atom Link Relation Handling (`tests/unit/test_feed.py`)**:
   - Extraction of `rel="replies"`, `rel="discussion"`, and `rel="comments"` candidate links.
   - Fallback and filtering when candidate links are empty or malformed.
3. **Security & Edge Cases (`tests/unit/test_feed.py`)**:
   - Rejection of non-string (int, dict, list), empty, whitespace, and unsafe URI schemes (`javascript:`, `data:`, `file:`, `ftp:`, `mailto:`, `tel:`, protocol-relative, no netloc).
4. **Database Update Idempotency (`tests/unit/test_feed.py`)**:
   - Verifies existing DB items have `comments_url` preserved when upstream feeds temporarily omit comments tags.
   - Verifies existing items get updated when new `comments_url` is provided.
5. **Backend API Serialization & Pagination (`tests/unit/test_app.py`)**:
   - `FeedItem.to_dict()` and `_get_top_items_for_feeds` in `backend/blueprints/tabs.py`.
   - Multi-page pagination (`/api/feeds/<feed_id>/items?limit=...&offset=...`) preserving `comments_url`.
6. **Frontend Vitest Component Suite (`frontend/js/ui.test.js`)**:
   - Primary discussion thread link (`title="Open discussion thread"`, `target="_blank"`, `rel="noopener noreferrer"`).
   - Secondary `[article]` link rendering with `aria-label`, accessibility metadata, and separator.
   - Single link fallback when `comments_url` is missing, whitespace, or equal to `link`.
   - URL scheme sanitization for discussion and article links.
   - Click and middle-click (`auxclick` with `button: 1`) mark-as-read handlers for both primary and secondary links.
   - Visual badge count updates and `unread`/`read` styling assertions.

### Test Verification

- **Vitest**: 36 passed across 3 test suites (100%)
- **Pytest Unit**: 173 passed across 18 test files (100%)
- **Playwright E2E**: 3 passed across 3 test files (100%)

## Summary by Sourcery

Add comprehensive tests for feed comments and discussion link handling across backend parsing, API serialization/pagination, and frontend UI interactions.

Documentation:
- Update TODO and CHANGELOG entries to document the expanded comments/discussion link test suite and refreshed test pass counts.

Tests:
- Strengthen frontend Vitest coverage for badges, unread count updates, feed widgets, tab rendering, modals, and progress helpers including discussion/article link behavior and mark-as-read interactions.
- Add backend unit tests for RSS/Atom parsing of Hacker News and Lobsters feeds, Atom link relations, malformed/unsafe comments URLs, and database idempotency of comments_url updates.
- Extend backend API tests to cover _get_top_items_for_feeds serialization and paginated /api/feeds/<feed_id>/items responses preserving comments_url.