### PR TITLE
docs(governance): enforce mandatory pull request policy and ban direct pushes to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AI Agents must respect the following rules
 
 - **Dependency & Version Policy**: Never downgrade dependencies, tools, or GitHub Action versions on a whim or based on outdated training assumptions. Always keep the latest release versions and empirically verify actual existence before making version changes.
+- **Strict Pull Request Policy (No Direct Pushes to `main`)**: Direct pushes to `main` are strictly forbidden under all circumstances. Every change (features, bug fixes, operational scripts, database migrations, configurations, and documentation) MUST be committed to a dedicated branch (`feat/...` or `fix/...`), submitted as a Pull Request via `gh pr create`, pass the full CI/testing and code review loop, and be merged via the PR workflow.
 
 ## An Agent must always start by reading **all** `.md` files from the repository in order to have a global understanding of the application. They must also read both backend & frontend code files to understand the app's logic. 
 
@@ -16,6 +17,7 @@
 5. Before preparing to end a task it is necessary to run a last full validation of all tests (Vitest frontend, Pytest unit, and Playwright E2E suites).
 6. Then it is necessary to update all relevant .md files (*especially* `TODO.md` and `CHANGELOG.md`) accordingly.
 7. Only then will the task be completed, and changes be submitted / committed.
+8. Changes must be pushed to the feature/fix branch and merged exclusively via a Pull Request. Never push directly to `main`.
 
 ### Tag & Release Workflow
 - **Automated GHCR & GitHub Releases**: Pushing a version tag matching `v*.*` (e.g. `v0.27`) triggers `.github/workflows/release.yml`, which automatically builds and publishes the container image to `ghcr.io/sheepdestroyer/sheepvibes:<TAG>` and `:latest`, and generates/updates the corresponding GitHub Release notes with the GitHub API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2026-08-14
 
+- **Docs & Governance: Enact Strict Pull Request Policy & Prohibition of Direct Pushes to `main`**
+  - **Rule Definition (`AGENTS.md`)**: Enacted strict policy that direct pushes to `main` are prohibited under all circumstances. Every change (features, bug fixes, operational scripts, database migrations, configuration, and documentation) must be made on a dedicated branch and merged via Pull Request.
+
 - **Feat: Canonical Short Feed Names & Single-Line Widget Title Bars**
   - **Single-Line Truncation & Compact Title Bar (`frontend/style.css`, `frontend/js/ui.js`)**: Enforced strict single-line CSS truncation (`white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;`) on widget title links and spans, added `.feed-widget-title` class and hover tooltip `title` attribute, and adjusted button vertical margins so widget title bars maintain a compact ~36px height while keeping 44px touch targets.
   - **Canonical Short Name Extraction (`backend/feed_name_utils.py`)**: Added `derive_canonical_feed_name` to clean verbose RSS channel `<title>` tags, stripping boilerplate suffixes (`- Articles`, `- News`, `| Homepage`, `:: RSS Feed`), boilerplate prefixes (`Latest from...`), domain artifacts (`www.theregister.com - Articles` → `The Register`), and pure marketing taglines (`GPU News, CPU News, Reviews & PC Hardware Guides` → `Wccftech`).

--- a/TODO.md
+++ b/TODO.md
@@ -147,6 +147,10 @@ This document outlines the steps to build the SheepVibes RSS aggregator.
 
 ## Process
 
+*   [x] **2026-08-14: Strict Pull Request Policy & Prohibition of Direct Pushes to `main`**
+  - [x] Enacted strict rule in `AGENTS.md` requiring all changes without exception to go through dedicated branches and Pull Requests.
+  - [x] Prohibited direct pushes to `main` under any circumstances.
+
 *   [x] **2026-08-14: Canonical Short Feed Names & Single-Line Widget Title Bars**
   - [x] Enforced strict single-line CSS truncation (`white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;`) and compact header layout in `frontend/style.css` and `frontend/js/ui.js`.
   - [x] Added `feed-widget-title` class and hover tooltip `title` attribute to feed widget headers.


### PR DESCRIPTION
### Summary of Changes

- **Strict Pull Request Policy (`AGENTS.md`)**:
  - Enacted mandatory rule prohibiting direct pushes to `main` under any circumstances.
  - Required all future changes (features, bug fixes, operational scripts, database migrations, configurations, documentation) to be made on dedicated branches (`feat/...`, `fix/...`, `docs/...`), submitted via Pull Requests (`gh pr create`), pass all CI/testing and code review loops, and merge exclusively via PRs.
- **Documentation Alignment (`TODO.md`, `CHANGELOG.md`)**:
  - Recorded governance update in project tasks and changelog.

### Verification
- **Vitest Frontend Suite**: 39/39 passed (100%).
- **Pytest Backend Unit Suite**: 194/194 passed (100%).

## Summary by Sourcery

Document and enforce a strict governance rule requiring all changes to go through dedicated branches and pull requests, with direct pushes to main fully prohibited.

Enhancements:
- Update AGENTS.md governance rules to mandate branch-based workflows, CI and review compliance, and PR-only merges for all changes.

Documentation:
- Record the new strict pull request governance policy and ban on direct pushes to main in TODO.md and CHANGELOG.md.